### PR TITLE
ci: Simplify event triggers in auto-approve workflow.

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yml
+++ b/.github/workflows/auto-approve-dependabot.yml
@@ -1,12 +1,7 @@
 name: Auto-approve and merge Dependabot PRs
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
+  pull_request
 
 jobs:
   auto-approve:


### PR DESCRIPTION
Updated the workflow to use the default pull_request event triggers, removing specific event types. This reduces redundancy and ensures all pull request activities are captured.