### PR TITLE
feat: add task update functionality to CLI

### DIFF
--- a/task-cli/src/main.rs
+++ b/task-cli/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use std::fs;
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
 use std::path::Path;
 use task_cli::TaskRepository;
 
@@ -15,6 +15,16 @@ enum Commands {
     Add { description: String },
     Update { id: u32, description: String },
     List,
+}
+
+fn open_file_and_truncate(path: &Path) -> File {
+    let file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(path)
+        .expect("cannot open file");
+    file
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -35,20 +45,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let mut file = OpenOptions::new()
-        .write(true)
-        .truncate(false)
-        .create(true)
-        .open(TASK_FILE)
-        .expect("cannot open file");
-
     match args.command {
         Commands::Add { description } => {
+            let mut file = open_file_and_truncate(path);
             let id = tasks.add(description);
             tasks.save_as_json(&mut file);
             println!("Task added with ID {}", id);
         }
         Commands::Update { id, description } => {
+            let mut file = open_file_and_truncate(path);
             tasks
                 .update_task(id, description)
                 .expect("cannot update task");


### PR DESCRIPTION
Introduced `update` command to modify task descriptions by ID. Added support in `TaskRepository` for updating tasks with error handling. Included corresponding tests to ensure functionality and maintain task integrity.