### PR TITLE
fix(workflows): use squash merge for Dependabot PRs

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yml
+++ b/.github/workflows/auto-approve-dependabot.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --rebase "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updated the auto-approve workflow to use squash merging instead of regular merging for Dependabot PRs. This ensures cleaner commit history by consolidating changes into a single commit.