### PR TITLE
fix: add logging initialization with env_logger

### DIFF
--- a/nicknamer/src/main.rs
+++ b/nicknamer/src/main.rs
@@ -26,6 +26,7 @@ async fn nick(_ctx: Context<'_>, member: serenity::Member) -> Result<(), Error> 
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
     let token = std::env::var("DISCORD_TOKEN").expect("missing DISCORD_TOKEN");
     let intents = serenity::GatewayIntents::non_privileged();
 


### PR DESCRIPTION
Initialize env_logger in the main function to enable logging capabilities. This provides better visibility into runtime behavior and simplifies debugging.