### PR TITLE
chore: remove multi-region config from railway.json

### DIFF
--- a/nicknamer/railway.json
+++ b/nicknamer/railway.json
@@ -13,11 +13,6 @@
       }
     },
     "sleepApplication": true,
-    "multiRegionConfig": {
-      "us-west2": {
-        "numReplicas": 1
-      }
-    },
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
The multi-region configuration was removed to simplify the deployment settings. This change ensures the application runs in a single region while maintaining the existing restart policies.