### PR TITLE
feat: allow revealing the names of specific people

### DIFF
--- a/nicknamer/src/main.rs
+++ b/nicknamer/src/main.rs
@@ -4,12 +4,15 @@ use self::nicknamer::commands::reveal;
 use crate::nicknamer::commands;
 use crate::nicknamer::discord;
 use crate::nicknamer::discord::DiscordConnector;
+use crate::nicknamer::discord::serenity::{Context, Error, SerenityDiscordConnector};
 use crate::nicknamer::file;
+use crate::nicknamer::file::RealNames;
 use log::{LevelFilter, info};
 use log4rs::Config;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Logger, Root};
 use poise::serenity_prelude as serenity;
+use poise::serenity_prelude::Member;
 
 /// Ping command to test bot availability
 ///
@@ -58,39 +61,46 @@ async fn reveal(
     info!("Loaded {} real names", real_names.names.len());
     let connector = discord::serenity::SerenityDiscordConnector::new(ctx);
     match member {
-        Some(member) => {
-            let server_member: discord::ServerMember = member.clone().into();
-            let user_id = server_member.id;
-            // Look up real name from the loaded real_names
-            let mut user: commands::User = server_member.into();
-            let real_name = real_names.names.get(&user_id).cloned();
-            user.real_name = real_name;
-            let reply = reveal::reveal_user(user)?;
-            ctx.reply(reply).await?;
-            Ok(())
-        }
-        None => {
-            info!("Revealing nicknames for current channel members ...");
-            let members = connector.get_members_of_current_channel().await?;
-            info!("Found {} members in current channel", members.len());
-            let users: Vec<commands::User> = members
-                .iter()
-                .filter_map(|member| {
-                    // Only include users with real names in our database
-                    let Some(real_name) = real_names.names.get(&member.id) else {
-                        return None;
-                    };
-                    let mut user: commands::User = member.into();
-                    user.real_name = Some(real_name.clone());
-                    Some(user)
-                })
-                .collect();
-            info!("Found {} users with real names", users.len());
-            let reply = commands::RealNames { users };
-            ctx.reply(reveal::reveal(&reply)?).await?;
-            Ok(())
-        }
+        Some(member) => reveal_single_member(ctx, &real_names, member).await,
+        None => reveal_multiple_members(ctx, real_names, connector).await?,
     }
+}
+
+async fn reveal_multiple_members(
+    ctx: Context<'_>,
+    real_names: RealNames,
+    connector: SerenityDiscordConnector<'_>,
+) -> Result<Result<(), Error>, Error> {
+    info!("Revealing nicknames for current channel members ...");
+    let members = connector.get_members_of_current_channel().await?;
+    info!("Found {} members in current channel", members.len());
+    let users: Vec<commands::User> = members
+        .iter()
+        .filter_map(|member| {
+            // Only include users with real names in our database
+            let Some(real_name) = real_names.names.get(&member.id) else {
+                return None;
+            };
+            let mut user: commands::User = member.into();
+            user.real_name = Some(real_name.clone());
+            Some(user)
+        })
+        .collect();
+    info!("Found {} users with real names", users.len());
+    let reply = commands::RealNames { users };
+    ctx.reply(reveal::reveal(&reply)?).await?;
+    Ok(Ok(()))
+}
+
+async fn reveal_single_member(
+    ctx: Context<'_>,
+    real_names: &RealNames,
+    member: Member,
+) -> Result<(), Error> {
+    let server_member: discord::ServerMember = member.clone().into();
+    let reply = reveal::reveal_member(server_member, real_names)?;
+    ctx.reply(reply).await?;
+    Ok(())
 }
 
 #[tokio::main]

--- a/nicknamer/src/main.rs
+++ b/nicknamer/src/main.rs
@@ -45,6 +45,9 @@ async fn nick(
     Ok(())
 }
 
+/// Reveal members' true names, greatly diminishing their power level
+///
+/// Specifically, I'll review the names of members that can access this channel.
 #[poise::command(prefix_command)]
 async fn reveal(ctx: discord::serenity::Context<'_>) -> Result<(), discord::serenity::Error> {
     info!("Revealing nicknames for current channel members ...");

--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -1,5 +1,6 @@
 use crate::nicknamer::discord;
 use poise::serenity_prelude as serenity;
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
 pub mod reveal;
@@ -37,7 +38,7 @@ impl Display for User {
 
 #[derive(Debug, PartialEq)]
 pub struct RealNames {
-    pub(crate) users: Vec<User>,
+    pub(crate) users: HashMap<u64, User>,
 }
 
 impl Display for RealNames {
@@ -47,7 +48,7 @@ impl Display for RealNames {
             "{}",
             self.users
                 .iter()
-                .map(|user| format!("{}", user))
+                .map(|(_, user)| format!("{}", user))
                 .collect::<Vec<String>>()
                 .join("\n")
         )

--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter};
 
 pub mod reveal;
 
-type Reply = String;
+pub(crate) type Reply = String;
 
 #[derive(Debug, PartialEq, Default)]
 pub struct User {

--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -40,10 +40,11 @@ impl From<&discord::ServerMember> for User {
 
 impl Display for User {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let Some(real_name) = &self.real_name else {
-            return Ok(());
-        };
-        write!(f, "'{}' is {}", self.display_name, real_name)
+        if let Some(real_name) = &self.real_name {
+            write!(f, "'{}' is {}", self.display_name, real_name)
+        } else {
+            write!(f, "'{}' has no real name available", self.display_name)
+        }
     }
 }
 
@@ -152,5 +153,88 @@ mod tests {
         assert_eq!(user.id, 24680);
         assert_eq!(user.display_name, "SameName");
         assert_eq!(user.real_name, Some("Real Name".into()));
+    }
+
+    #[test]
+    fn test_user_display_with_real_name() {
+        // Arrange
+        let user = User {
+            id: 12345,
+            display_name: "DisplayName".to_string(),
+            real_name: Some("RealName".to_string()),
+        };
+
+        // Act
+        let display_string = format!("{}", user);
+
+        // Assert
+        assert_eq!(display_string, "'DisplayName' is RealName");
+    }
+
+    #[test]
+    fn test_user_display_without_real_name() {
+        // Arrange
+        let user = User {
+            id: 12345,
+            display_name: "DisplayName".to_string(),
+            real_name: None,
+        };
+
+        // Act
+        let display_string = format!("{}", user);
+
+        // Assert
+        assert_eq!(display_string, "'DisplayName' has no real name available");
+    }
+
+    #[test]
+    fn test_user_display_with_empty_display_name() {
+        // Arrange
+        let user = User {
+            id: 12345,
+            display_name: "".to_string(),
+            real_name: Some("RealName".to_string()),
+        };
+
+        // Act
+        let display_string = format!("{}", user);
+
+        // Assert
+        assert_eq!(display_string, "'' is RealName");
+    }
+
+    #[test]
+    fn test_user_display_with_special_characters() {
+        // Arrange
+        let user = User {
+            id: 12345,
+            display_name: "Name\"With'Quotes".to_string(),
+            real_name: Some("Real\"Name'With'Quotes".to_string()),
+        };
+
+        // Act
+        let display_string = format!("{}", user);
+
+        // Assert
+        assert_eq!(
+            display_string,
+            "'Name\"With'Quotes' is Real\"Name'With'Quotes"
+        );
+    }
+
+    #[test]
+    fn test_user_display_with_empty_real_name() {
+        // Arrange - edge case with empty string (not None) for real_name
+        let user = User {
+            id: 12345,
+            display_name: "DisplayName".to_string(),
+            real_name: Some("".to_string()),
+        };
+
+        // Act
+        let display_string = format!("{}", user);
+
+        // Assert
+        assert_eq!(display_string, "'DisplayName' is ");
     }
 }

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -3,16 +3,28 @@ use crate::nicknamer::config;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub fn reveal(real_names: &RealNames) -> Result<Reply, Error> {
+    let users = real_names
+        .users
+        .iter()
+        .filter(|user| user.real_name.is_some())
+        .map(|user| user.to_string())
+        .collect::<Vec<String>>();
     Ok(format!(
         "Here are people's real names, {}:
 {}",
         config::REVEAL_INSULT,
-        real_names
+        users.join("\n")
     ))
 }
 
 pub fn reveal_user(user: User) -> Result<Reply, Error> {
-    Ok(user.to_string())
+    match user.real_name {
+        Some(_) => Ok(user.to_string()),
+        None => Ok(format!(
+            "How mysterious! {}'s true name is shrouded by darkness",
+            user.display_name
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -20,28 +32,21 @@ mod tests {
     use crate::nicknamer::commands::reveal;
     use crate::nicknamer::commands::*;
     use crate::nicknamer::config;
-    use std::collections::HashMap;
 
     fn setup_test_data() -> RealNames {
-        let mut users = HashMap::new();
+        let mut users = Vec::new();
 
-        users.insert(
-            1,
-            User {
-                id: 1,
-                display_name: "Alice's nickname".to_string(),
-                real_name: "Alice".to_string(),
-            },
-        );
+        users.push(User {
+            id: 1,
+            display_name: "Alice's nickname".to_string(),
+            real_name: Some("Alice".to_string()),
+        });
 
-        users.insert(
-            2,
-            User {
-                id: 2,
-                display_name: "Bob's nickname".to_string(),
-                real_name: "Bob".to_string(),
-            },
-        );
+        users.push(User {
+            id: 2,
+            display_name: "Bob's nickname".to_string(),
+            real_name: Some("Bob".to_string()),
+        });
 
         RealNames { users }
     }
@@ -71,9 +76,7 @@ mod tests {
 
     #[test]
     fn can_reveal_users_even_if_there_are_no_real_names() {
-        let empty_real_names = RealNames {
-            users: HashMap::new(),
-        };
+        let empty_real_names = RealNames { users: Vec::new() };
         let result = reveal::reveal(&empty_real_names).unwrap();
 
         // For empty names, we can still do an exact match as there's no ordering issue
@@ -89,12 +92,26 @@ mod tests {
         let existing_result = reveal::reveal_user(User {
             id: 0,
             display_name: "Alice's nickname".to_string(),
-            real_name: "Alice".to_string(),
+            real_name: Some("Alice".to_string()),
         })
         .unwrap();
         assert_eq!(existing_result, "'Alice's nickname' is Alice");
     }
 
     #[test]
-    fn revealing_user_with_no_nickname_results_in_insult() {}
+    fn revealing_user_with_no_nickname_results_in_insult() {
+        // Test for a user with no real name
+        let result = reveal::reveal_user(User {
+            id: 0,
+            display_name: "Unknown User".to_string(),
+            real_name: None,
+        })
+        .unwrap();
+
+        // The Display implementation for User should return an empty string when real_name is None
+        assert_eq!(
+            result,
+            "How mysterious! Unknown User's true name is shrouded by darkness"
+        );
+    }
 }

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -1,5 +1,6 @@
 use crate::nicknamer::commands::{RealNames, Reply, User};
-use crate::nicknamer::config;
+use crate::nicknamer::discord::{ServerMember, serenity};
+use crate::nicknamer::{config, file};
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub fn reveal(real_names: &RealNames) -> Result<Reply, Error> {
@@ -17,7 +18,18 @@ pub fn reveal(real_names: &RealNames) -> Result<Reply, Error> {
     ))
 }
 
-pub fn reveal_user(user: User) -> Result<Reply, Error> {
+pub fn reveal_member(
+    server_member: ServerMember,
+    real_names: &file::RealNames,
+) -> Result<Reply, serenity::Error> {
+    let user_id = server_member.id;
+    let mut user: User = server_member.into();
+    let real_name = real_names.names.get(&user_id).cloned();
+    user.real_name = real_name;
+    create_reply(user)
+}
+
+fn create_reply(user: User) -> Result<Reply, Error> {
     match user.real_name {
         Some(_) => Ok(user.to_string()),
         None => Ok(format!(
@@ -31,77 +43,164 @@ pub fn reveal_user(user: User) -> Result<Reply, Error> {
 mod tests {
     use crate::nicknamer::commands::reveal;
     use crate::nicknamer::commands::*;
-    use crate::nicknamer::config;
+    use crate::nicknamer::discord::ServerMember;
+    use crate::nicknamer::file::RealNames;
+    use std::collections::HashMap;
 
-    fn setup_test_data() -> RealNames {
-        let mut users = Vec::new();
+    fn create_test_real_names() -> RealNames {
+        let mut names = HashMap::new();
+        names.insert(123456789, "Alice".to_string());
+        names.insert(987654321, "Bob".to_string());
+        RealNames { names }
+    }
 
-        users.push(User {
-            id: 1,
-            display_name: "Alice's nickname".to_string(),
-            real_name: Some("Alice".to_string()),
-        });
-
-        users.push(User {
-            id: 2,
-            display_name: "Bob's nickname".to_string(),
-            real_name: Some("Bob".to_string()),
-        });
-
-        RealNames { users }
+    fn create_server_member(id: u64, nickname: Option<String>, username: String) -> ServerMember {
+        ServerMember {
+            id,
+            nick_name: nickname,
+            user_name: username,
+        }
     }
 
     #[test]
-    fn can_reveal_users_with_real_names() {
-        let real_names = setup_test_data();
-        let result = reveal::reveal(&real_names).unwrap();
-
-        // Check that the output starts with the expected header
-        let header = format!("Here are people's real names, {}:", config::REVEAL_INSULT);
-        assert!(
-            result.starts_with(&header),
-            "Result should start with the header"
+    fn test_reveal_member_with_real_name() {
+        // Setup
+        let real_names = create_test_real_names();
+        let server_member = create_server_member(
+            123456789,
+            Some("AliceNickname".to_string()),
+            "AliceUsername".to_string(),
         );
 
-        // Check for each expected user string in the output
-        assert!(
-            result.contains("'Alice's nickname' is Alice"),
-            "Result should contain Alice's information"
-        );
-        assert!(
-            result.contains("'Bob's nickname' is Bob"),
-            "Result should contain Bob's information"
-        );
+        // Call the function
+        let result = reveal::reveal_member(server_member, &real_names).unwrap();
+
+        // The result should contain the user's nickname (or username if no nickname) and real name
+        assert_eq!(result, "'AliceNickname' is Alice");
     }
 
     #[test]
-    fn can_reveal_users_even_if_there_are_no_real_names() {
-        let empty_real_names = RealNames { users: Vec::new() };
-        let result = reveal::reveal(&empty_real_names).unwrap();
+    fn test_reveal_member_without_nickname() {
+        // Setup - member with username but no nickname
+        let real_names = create_test_real_names();
+        let server_member = create_server_member(123456789, None, "AliceUsername".to_string());
 
-        // For empty names, we can still do an exact match as there's no ordering issue
+        // Call the function
+        let result = reveal::reveal_member(server_member, &real_names).unwrap();
+
+        // Should use the username when no nickname is available
+        assert_eq!(result, "'AliceUsername' is Alice");
+    }
+
+    #[test]
+    fn test_reveal_member_without_real_name() {
+        // Setup - member with an ID that doesn't exist in real_names
+        let real_names = create_test_real_names();
+        let server_member = create_server_member(
+            111222333,
+            Some("UnknownNickname".to_string()),
+            "UnknownUsername".to_string(),
+        );
+
+        // Call the function
+        let result = reveal::reveal_member(server_member, &real_names).unwrap();
+
+        // Should return the "mysterious" message for users without real names
         assert_eq!(
             result,
-            format!("Here are people's real names, {}:\n", config::REVEAL_INSULT)
+            "How mysterious! UnknownNickname's true name is shrouded by darkness"
         );
     }
 
     #[test]
-    fn can_reveal_single_user() {
-        // Test for an existing member
-        let existing_result = reveal::reveal_user(User {
-            id: 0,
-            display_name: "Alice's nickname".to_string(),
-            real_name: Some("Alice".to_string()),
-        })
-        .unwrap();
-        assert_eq!(existing_result, "'Alice's nickname' is Alice");
+    fn test_reveal_member_with_special_characters() {
+        // Setup
+        let mut real_names = create_test_real_names();
+        real_names
+            .names
+            .insert(555666777, "User with \"quotes\"".to_string());
+        let server_member = create_server_member(
+            555666777,
+            Some("Nickname'With'Apostrophes".to_string()),
+            "Username".to_string(),
+        );
+
+        // Call the function
+        let result = reveal::reveal_member(server_member, &real_names).unwrap();
+
+        // Should handle special characters correctly
+        assert_eq!(
+            result,
+            "'Nickname'With'Apostrophes' is User with \"quotes\""
+        );
+    }
+
+    #[test]
+    fn test_reveal_member_preserves_nickname_case() {
+        // Setup
+        let real_names = create_test_real_names();
+        let server_member = create_server_member(
+            123456789,
+            Some("ALICE_UPPERCASE".to_string()),
+            "alice_lowercase".to_string(),
+        );
+
+        // Call the function
+        let result = reveal::reveal_member(server_member, &real_names).unwrap();
+
+        // Should preserve the nickname case exactly
+        assert_eq!(result, "'ALICE_UPPERCASE' is Alice");
+    }
+
+    #[test]
+    fn test_multiple_members_with_same_real_name() {
+        // Setup - two members with the same real name
+        let mut real_names = create_test_real_names();
+        real_names.names.insert(111222333, "Bob".to_string());
+
+        // First member
+        let server_member1 = create_server_member(
+            987654321,
+            Some("BobNickname1".to_string()),
+            "BobUsername1".to_string(),
+        );
+        let result1 = reveal::reveal_member(server_member1, &real_names).unwrap();
+
+        // Second member
+        let server_member2 = create_server_member(
+            111222333,
+            Some("BobNickname2".to_string()),
+            "BobUsername2".to_string(),
+        );
+        let result2 = reveal::reveal_member(server_member2, &real_names).unwrap();
+
+        // Different nicknames but same real name
+        assert_eq!(result1, "'BobNickname1' is Bob");
+        assert_eq!(result2, "'BobNickname2' is Bob");
+    }
+
+    #[test]
+    fn test_conversion_from_server_member_to_user() {
+        // Setup
+        let server_member = create_server_member(
+            123456789,
+            Some("Nickname".to_string()),
+            "Username".to_string(),
+        );
+
+        // Convert to User manually as reveal_member would do
+        let user: User = server_member.into();
+
+        // Verify conversion worked as expected
+        assert_eq!(user.id, 123456789);
+        assert_eq!(user.display_name, "Nickname");
+        assert_eq!(user.real_name, None); // real_name should be None initially
     }
 
     #[test]
     fn revealing_user_with_no_nickname_results_in_insult() {
         // Test for a user with no real name
-        let result = reveal::reveal_user(User {
+        let result = reveal::create_reply(User {
             id: 0,
             display_name: "Unknown User".to_string(),
             real_name: None,

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -1,4 +1,4 @@
-use crate::nicknamer::commands::{RealNames, Reply};
+use crate::nicknamer::commands::{RealNames, Reply, User};
 use crate::nicknamer::config;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -11,11 +11,8 @@ pub fn reveal(real_names: &RealNames) -> Result<Reply, Error> {
     ))
 }
 
-pub fn reveal_member(id: u64, real_names: &RealNames) -> Result<Reply, Error> {
-    match real_names.users.get(&id) {
-        Some(user) => Ok(format!("'{}' is {}", user.display_name, user.real_name)),
-        None => Ok("No one has that id".to_string()),
-    }
+pub fn reveal_user(user: User) -> Result<Reply, Error> {
+    Ok(user.to_string())
 }
 
 #[cfg(test)]
@@ -50,7 +47,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_existing_user() {
+    fn can_reveal_users_with_real_names() {
         let real_names = setup_test_data();
         let result = reveal::reveal(&real_names).unwrap();
 
@@ -73,7 +70,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_empty_names() {
+    fn can_reveal_users_even_if_there_are_no_real_names() {
         let empty_real_names = RealNames {
             users: HashMap::new(),
         };
@@ -87,15 +84,17 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_member() {
-        let real_names = setup_test_data();
-
+    fn can_reveal_single_user() {
         // Test for an existing member
-        let existing_result = reveal::reveal_member(1, &real_names).unwrap();
+        let existing_result = reveal::reveal_user(User {
+            id: 0,
+            display_name: "Alice's nickname".to_string(),
+            real_name: "Alice".to_string(),
+        })
+        .unwrap();
         assert_eq!(existing_result, "'Alice's nickname' is Alice");
-
-        // Test for a non-existent member
-        let nonexistent_result = reveal::reveal_member(999, &real_names).unwrap();
-        assert_eq!(nonexistent_result, "No one has that id");
     }
+
+    #[test]
+    fn revealing_user_with_no_nickname_results_in_insult() {}
 }

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -1,9 +1,8 @@
 use crate::nicknamer::commands::{RealNames, Reply};
 use crate::nicknamer::config;
 
-pub fn reveal(
-    real_names: &RealNames,
-) -> Result<Reply, Box<dyn std::error::Error + Send + Sync + 'static>> {
+type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub fn reveal(real_names: &RealNames) -> Result<Reply, Error> {
     Ok(format!(
         "Here are people's real names, {}:
 {}",
@@ -12,49 +11,91 @@ pub fn reveal(
     ))
 }
 
+pub fn reveal_member(id: u64, real_names: &RealNames) -> Result<Reply, Error> {
+    match real_names.users.get(&id) {
+        Some(user) => Ok(format!("'{}' is {}", user.display_name, user.real_name)),
+        None => Ok("No one has that id".to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::nicknamer::commands::reveal;
     use crate::nicknamer::commands::*;
     use crate::nicknamer::config;
+    use std::collections::HashMap;
 
     fn setup_test_data() -> RealNames {
-        RealNames {
-            users: vec![
-                User {
-                    id: 1,
-                    display_name: "Alice's nickname".to_string(),
-                    real_name: "Alice".to_string(),
-                },
-                User {
-                    id: 2,
-                    display_name: "Bob's nickname".to_string(),
-                    real_name: "Bob".to_string(),
-                },
-            ],
-        }
+        let mut users = HashMap::new();
+
+        users.insert(
+            1,
+            User {
+                id: 1,
+                display_name: "Alice's nickname".to_string(),
+                real_name: "Alice".to_string(),
+            },
+        );
+
+        users.insert(
+            2,
+            User {
+                id: 2,
+                display_name: "Bob's nickname".to_string(),
+                real_name: "Bob".to_string(),
+            },
+        );
+
+        RealNames { users }
     }
 
     #[test]
     fn test_reveal_existing_user() {
         let real_names = setup_test_data();
-        let result = reveal::reveal(&real_names);
-        assert_eq!(
-            result.unwrap(),
-            format!(
-                "Here are people's real names, {}:\n'Alice's nickname' is Alice\n'Bob's nickname' is Bob",
-                config::REVEAL_INSULT
-            )
+        let result = reveal::reveal(&real_names).unwrap();
+
+        // Check that the output starts with the expected header
+        let header = format!("Here are people's real names, {}:", config::REVEAL_INSULT);
+        assert!(
+            result.starts_with(&header),
+            "Result should start with the header"
+        );
+
+        // Check for each expected user string in the output
+        assert!(
+            result.contains("'Alice's nickname' is Alice"),
+            "Result should contain Alice's information"
+        );
+        assert!(
+            result.contains("'Bob's nickname' is Bob"),
+            "Result should contain Bob's information"
         );
     }
 
     #[test]
     fn test_reveal_empty_names() {
-        let empty_real_names = RealNames { users: Vec::new() };
-        let result = reveal::reveal(&empty_real_names);
+        let empty_real_names = RealNames {
+            users: HashMap::new(),
+        };
+        let result = reveal::reveal(&empty_real_names).unwrap();
+
+        // For empty names, we can still do an exact match as there's no ordering issue
         assert_eq!(
-            result.unwrap(),
+            result,
             format!("Here are people's real names, {}:\n", config::REVEAL_INSULT)
         );
+    }
+
+    #[test]
+    fn test_reveal_member() {
+        let real_names = setup_test_data();
+
+        // Test for an existing member
+        let existing_result = reveal::reveal_member(1, &real_names).unwrap();
+        assert_eq!(existing_result, "'Alice's nickname' is Alice");
+
+        // Test for a non-existent member
+        let nonexistent_result = reveal::reveal_member(999, &real_names).unwrap();
+        assert_eq!(nonexistent_result, "No one has that id");
     }
 }

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -1,5 +1,5 @@
 use crate::nicknamer::commands::{Reply, User};
-use crate::nicknamer::discord::{ServerMember, serenity};
+use crate::nicknamer::discord::ServerMember;
 use crate::nicknamer::{config, file};
 use log::info;
 
@@ -8,7 +8,7 @@ type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub fn reveal_member(
     server_member: ServerMember,
     real_names: &file::RealNames,
-) -> Result<Reply, serenity::Error> {
+) -> Result<Reply, Error> {
     let user_id = server_member.id;
     let mut user: User = server_member.into();
     let real_name = real_names.names.get(&user_id).cloned();

--- a/nicknamer/src/nicknamer/discord/serenity.rs
+++ b/nicknamer/src/nicknamer/discord/serenity.rs
@@ -2,8 +2,8 @@
 //!
 //! This module provides the concrete implementation of the Discord connector
 //! trait using the Serenity Discord library.
-
 use crate::nicknamer::discord::{DiscordConnector, ServerMember};
+use poise::serenity_prelude as serenity;
 
 /// Discord connector implementation using Serenity library.
 ///
@@ -34,13 +34,19 @@ impl DiscordConnector for SerenityDiscordConnector<'_> {
         let members = channel.members(ctx)?;
         let members = members
             .iter()
-            .map(|member| ServerMember {
-                id: member.user.id.get(),
-                nick_name: member.nick.clone(),
-                user_name: member.user.name.clone(),
-            })
+            .map(|member| ServerMember::from(member))
             .collect();
         Ok(members)
+    }
+}
+
+impl From<&serenity::Member> for ServerMember {
+    fn from(member: &serenity::Member) -> Self {
+        ServerMember {
+            id: member.user.id.get(),
+            nick_name: member.nick.clone(),
+            user_name: member.user.name.clone(),
+        }
     }
 }
 

--- a/nicknamer/src/nicknamer/discord/serenity.rs
+++ b/nicknamer/src/nicknamer/discord/serenity.rs
@@ -32,16 +32,13 @@ impl DiscordConnector for SerenityDiscordConnector<'_> {
             return Err("You're not in a discord server's channel".into());
         };
         let members = channel.members(ctx)?;
-        let members = members
-            .iter()
-            .map(|member| ServerMember::from(member))
-            .collect();
+        let members = members.iter().map(|member| member.clone().into()).collect();
         Ok(members)
     }
 }
 
-impl From<&serenity::Member> for ServerMember {
-    fn from(member: &serenity::Member) -> Self {
+impl From<serenity::Member> for ServerMember {
+    fn from(member: serenity::Member) -> Self {
         ServerMember {
             id: member.user.id.get(),
             nick_name: member.nick.clone(),


### PR DESCRIPTION
This pull request introduces significant enhancements to the `nicknamer` module, focusing on improving the functionality and flexibility of the "reveal" command. Key changes include refactoring the `User` struct to support optional real names, splitting the "reveal" logic into separate functions for individual and group operations, and adding comprehensive test coverage for edge cases and special scenarios.

### Enhancements to the "reveal" command:

* **Support for optional real names**: The `User` struct now uses an `Option<String>` for `real_name`, allowing for cases where a real name is unavailable. This change is reflected in the `Display` implementation to handle such scenarios gracefully (`nicknamer/src/nicknamer/commands/mod.rs`).

* **Refactored "reveal" logic**: The `reveal` command has been split into `reveal_member` and `reveal_all_members` functions, enabling targeted operations for individual members or all members in a channel. This improves modularity and code readability (`nicknamer/src/nicknamer/commands/reveal.rs`).

### Code refactoring and simplification:

* **Removed redundant methods**: The `from_discord_server_member` method in the `User` struct has been replaced with `From` trait implementations for `ServerMember` and `&ServerMember`, simplifying the conversion logic (`nicknamer/src/nicknamer/commands/mod.rs`).

* **Improved reply generation**: The `create_reply_for` and `create_reply_for_all` functions centralize the logic for generating responses, reducing duplication and improving maintainability (`nicknamer/src/nicknamer/commands/reveal.rs`).

### Test coverage improvements:

* **Expanded test cases**: New tests have been added to cover edge cases, such as members without real names, special characters in names, and empty member lists. These tests ensure robustness and correctness of the "reveal" functionality (`nicknamer/src/nicknamer/commands/reveal.rs`).

* **Validation of `Display` implementation**: Tests verify that the `Display` trait for `User` handles scenarios with and without real names correctly (`nicknamer/src/nicknamer/commands/mod.rs`).

### Dependency updates:

* **Serenity library integration**: Additional Serenity types (`Context`, `Error`, `Member`) have been imported to support the new functionality (`nicknamer/src/main.rs`).

These changes collectively enhance the maintainability, flexibility, and reliability of the "reveal" command while ensuring a more user-friendly experience.