### PR TITLE
refactor: remove unused RealNames struct and implementation

### DIFF
--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -48,25 +48,6 @@ impl Display for User {
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct RealNames {
-    pub(crate) users: Vec<User>,
-}
-
-impl Display for RealNames {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.users
-                .iter()
-                .map(|user| format!("{}", user))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-
 #[allow(dead_code)]
 pub fn nick(_user_id: serenity::UserId) {}
 


### PR DESCRIPTION
This pull request removes the `RealNames` struct and its `Display` implementation from the `nicknamer/src/nicknamer/commands/mod.rs` file. This change simplifies the codebase by eliminating unused or unnecessary functionality.

Codebase simplification:

* Removed the `RealNames` struct, which contained a `users` field of type `Vec<User>`, and its associated `Display` implementation. This struct and its functionality were likely unused or redundant.