### PR TITLE
test: introduce stubbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +622,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -1270,12 +1282,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "nicknamer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
  "log4rs",
+ "mockall",
  "poise",
  "serde",
  "serde_yml",

--- a/nicknamer/Cargo.toml
+++ b/nicknamer/Cargo.toml
@@ -12,3 +12,4 @@ serde_yml = "0.0.12"
 tokio = { version = "1.44.2", features = ["full"] }
 anyhow = "1.0.98"
 thiserror = "2.0.12"
+mockall = "0.13.1"

--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -58,7 +58,7 @@ mod tests {
     use crate::nicknamer::connectors::discord::ServerMember;
 
     #[test]
-    fn test_from_discord_server_member_with_nickname() {
+    fn can_convert_server_member_with_nickname_to_user() {
         // Arrange
         let member = ServerMember {
             id: 12345,
@@ -78,7 +78,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_discord_server_member_without_nickname() {
+    fn can_convert_server_member_without_nickname_using_username_fallback() {
         // Arrange
         let member = ServerMember {
             id: 67890,
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_discord_server_member_empty_nickname() {
+    fn can_handle_empty_nickname_when_converting_server_member() {
         // Arrange
         let member = ServerMember {
             id: 13579,
@@ -118,7 +118,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_discord_server_member_with_matching_names() {
+    fn can_convert_server_member_when_nickname_matches_username() {
         // Arrange - when nickname matches username
         let member = ServerMember {
             id: 24680,
@@ -138,7 +138,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_display_with_real_name() {
+    fn can_format_user_with_real_name_for_display() {
         // Arrange
         let user = User {
             id: 12345,
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_display_without_real_name() {
+    fn can_format_user_without_real_name_for_display() {
         // Arrange
         let user = User {
             id: 12345,
@@ -170,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_display_with_empty_display_name() {
+    fn can_format_user_with_empty_display_name() {
         // Arrange
         let user = User {
             id: 12345,
@@ -186,7 +186,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_display_with_special_characters() {
+    fn can_handle_special_characters_when_formatting_user() {
         // Arrange
         let user = User {
             id: 12345,
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_display_with_empty_real_name() {
+    fn can_format_user_with_empty_real_name_string() {
         // Arrange - edge case with empty string (not None) for real_name
         let user = User {
             id: 12345,

--- a/nicknamer/src/nicknamer/commands/names/mod.rs
+++ b/nicknamer/src/nicknamer/commands/names/mod.rs
@@ -1,3 +1,4 @@
+use crate::nicknamer::commands::names::Error::CannotLoadNames;
 use log::info;
 use mockall::automock;
 use serde::{Deserialize, Serialize};
@@ -5,8 +6,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Failed to parse YAML")]
-    SerdeYamlError(#[from] serde_yml::Error),
+    #[error("Failed to load names")]
+    CannotLoadNames,
 }
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Names {
@@ -32,7 +33,7 @@ impl EmbeddedNamesRepository {
 
 impl NamesRepository for EmbeddedNamesRepository {
     async fn load_real_names(&self) -> Result<Names, Error> {
-        let names: Names = serde_yml::from_str(self.embedded_names)?;
+        let names: Names = serde_yml::from_str(self.embedded_names).map_err(|_| CannotLoadNames)?;
         info!("Loaded {} names", names.names.len());
         Ok(names)
     }

--- a/nicknamer/src/nicknamer/commands/names/mod.rs
+++ b/nicknamer/src/nicknamer/commands/names/mod.rs
@@ -9,7 +9,7 @@ pub enum Error {
     #[error("Failed to load names")]
     CannotLoadNames,
 }
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Names {
     pub(crate) names: std::collections::HashMap<u64, String>,
 }

--- a/nicknamer/src/nicknamer/commands/names/mod.rs
+++ b/nicknamer/src/nicknamer/commands/names/mod.rs
@@ -1,4 +1,5 @@
 use log::info;
+use mockall::automock;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -12,6 +13,7 @@ pub struct Names {
     pub(crate) names: std::collections::HashMap<u64, String>,
 }
 
+#[automock]
 pub trait NamesRepository {
     async fn load_real_names(&self) -> Result<Names, Error>;
 }

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -504,15 +504,6 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn handles_names_error_when_revealing_all() {
-            // Setup mock objects
-            let mut mock_repo = MockNamesRepository::new();
-            let mut mock_discord = MockDiscordConnector::new();
-
-            // Define test data
-        }
-
-        #[tokio::test]
         async fn can_successfully_reveal_single_member() {
             // Setup mock objects
             let mut mock_repo = MockNamesRepository::new();

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -55,7 +55,7 @@ impl<'a, REPO: NamesRepository, DISCORD: DiscordConnector> Revealer
     }
 }
 
-pub fn reveal_member(server_member: &ServerMember, real_names: &Names) -> Result<Reply, Error> {
+fn reveal_member(server_member: &ServerMember, real_names: &Names) -> Result<Reply, Error> {
     let user_id = server_member.id;
     let mut user: User = server_member.into();
     let real_name = real_names.names.get(&user_id).cloned();
@@ -118,7 +118,6 @@ fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
 mod tests {
     use crate::nicknamer::commands::names::Names;
     use crate::nicknamer::commands::reveal;
-    use crate::nicknamer::commands::*;
     use crate::nicknamer::config;
     use crate::nicknamer::connectors::discord::ServerMember;
     use std::collections::HashMap;
@@ -185,108 +184,6 @@ mod tests {
         assert_eq!(
             result,
             "How mysterious! UnknownNickname's true name is shrouded by darkness"
-        );
-    }
-
-    #[test]
-    fn can_reveal_member_with_special_characters() {
-        // Setup
-        let mut real_names = create_test_real_names();
-        real_names
-            .names
-            .insert(555666777, "User with \"quotes\"".to_string());
-        let server_member = create_server_member(
-            555666777,
-            Some("Nickname'With'Apostrophes".to_string()),
-            "Username".to_string(),
-        );
-
-        // Call the function
-        let result = reveal::reveal_member(&server_member, &real_names).unwrap();
-
-        // Should handle special characters correctly
-        assert_eq!(
-            result,
-            "'Nickname'With'Apostrophes' is User with \"quotes\""
-        );
-    }
-
-    #[test]
-    fn can_preserve_nickname_case_when_revealing_member() {
-        // Setup
-        let real_names = create_test_real_names();
-        let server_member = create_server_member(
-            123456789,
-            Some("ALICE_UPPERCASE".to_string()),
-            "alice_lowercase".to_string(),
-        );
-
-        // Call the function
-        let result = reveal::reveal_member(&server_member, &real_names).unwrap();
-
-        // Should preserve the nickname case exactly
-        assert_eq!(result, "'ALICE_UPPERCASE' is Alice");
-    }
-
-    #[test]
-    fn can_reveal_multiple_members_with_same_real_name() {
-        // Setup - two members with the same real name
-        let mut real_names = create_test_real_names();
-        real_names.names.insert(111222333, "Bob".to_string());
-
-        // First member
-        let server_member1 = create_server_member(
-            987654321,
-            Some("BobNickname1".to_string()),
-            "BobUsername1".to_string(),
-        );
-        let result1 = reveal::reveal_member(&server_member1, &real_names).unwrap();
-
-        // Second member
-        let server_member2 = create_server_member(
-            111222333,
-            Some("BobNickname2".to_string()),
-            "BobUsername2".to_string(),
-        );
-        let result2 = reveal::reveal_member(&server_member2, &real_names).unwrap();
-
-        // Different nicknames but same real name
-        assert_eq!(result1, "'BobNickname1' is Bob");
-        assert_eq!(result2, "'BobNickname2' is Bob");
-    }
-
-    #[test]
-    fn can_convert_server_member_to_user() {
-        // Setup
-        let server_member = create_server_member(
-            123456789,
-            Some("Nickname".to_string()),
-            "Username".to_string(),
-        );
-
-        // Convert to User manually as reveal_member would do
-        let user: User = server_member.into();
-
-        // Verify conversion worked as expected
-        assert_eq!(user.id, 123456789);
-        assert_eq!(user.display_name, "Nickname");
-        assert_eq!(user.real_name, None); // real_name should be None initially
-    }
-
-    #[test]
-    fn can_get_mysterious_message_for_user_without_real_name() {
-        // Test for a user with no real name
-        let result = reveal::create_reply_for(&User {
-            id: 0,
-            display_name: "Unknown User".to_string(),
-            real_name: None,
-        })
-        .unwrap();
-
-        // The Display implementation for User should return an empty string when real_name is None
-        assert_eq!(
-            result,
-            "How mysterious! Unknown User's true name is shrouded by darkness"
         );
     }
 

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -116,81 +116,10 @@ fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
 
 #[cfg(test)]
 mod tests {
-    use crate::nicknamer::commands::names::Names;
-    use crate::nicknamer::commands::reveal;
-    use crate::nicknamer::connectors::discord::ServerMember;
-    use std::collections::HashMap;
-
-    fn create_test_real_names() -> Names {
-        let mut names = HashMap::new();
-        names.insert(123456789, "Alice".to_string());
-        names.insert(987654321, "Bob".to_string());
-        Names { names }
-    }
-
-    fn create_server_member(id: u64, nickname: Option<String>, username: String) -> ServerMember {
-        ServerMember {
-            id,
-            nick_name: nickname,
-            user_name: username,
-        }
-    }
-
-    #[test]
-    fn can_reveal_member_with_real_name() {
-        // Setup
-        let real_names = create_test_real_names();
-        let server_member = create_server_member(
-            123456789,
-            Some("AliceNickname".to_string()),
-            "AliceUsername".to_string(),
-        );
-
-        // Call the function
-        let result = reveal::reveal_member(&server_member, &real_names).unwrap();
-
-        // The result should contain the user's nickname (or username if no nickname) and real name
-        assert_eq!(result, "'AliceNickname' is Alice");
-    }
-
-    #[test]
-    fn can_reveal_member_without_nickname() {
-        // Setup - member with username but no nickname
-        let real_names = create_test_real_names();
-        let server_member = create_server_member(123456789, None, "AliceUsername".to_string());
-
-        // Call the function
-        let result = reveal::reveal_member(&server_member, &real_names).unwrap();
-
-        // Should use the username when no nickname is available
-        assert_eq!(result, "'AliceUsername' is Alice");
-    }
-
-    #[test]
-    fn can_reveal_member_without_real_name() {
-        // Setup - member with an ID that doesn't exist in real_names
-        let real_names = create_test_real_names();
-        let server_member = create_server_member(
-            111222333,
-            Some("UnknownNickname".to_string()),
-            "UnknownUsername".to_string(),
-        );
-
-        // Call the function
-        let result = reveal::reveal_member(&server_member, &real_names).unwrap();
-
-        // Should return the "mysterious" message for users without real names
-        assert_eq!(
-            result,
-            "How mysterious! UnknownNickname's true name is shrouded by darkness"
-        );
-    }
-
     // Tests for RevealerImpl using MockDiscordConnector and MockNamesRepository
     mod revealer_impl_tests {
-        use super::*;
         use crate::nicknamer::commands::names::{MockNamesRepository, Names};
-        use crate::nicknamer::commands::reveal::{Revealer, RevealerImpl};
+        use crate::nicknamer::commands::reveal::{Error, Revealer, RevealerImpl};
         use crate::nicknamer::connectors::discord::{MockDiscordConnector, ServerMember};
         use mockall::predicate::*;
         use std::collections::HashMap;
@@ -270,7 +199,7 @@ mod tests {
             // Verify results
             assert!(result.is_err(), "reveal_all should fail");
             assert!(
-                matches!(result.unwrap_err(), reveal::Error::DiscordError(_)),
+                matches!(result.unwrap_err(), Error::DiscordError(_)),
                 "Error should be a DiscordError"
             );
         }
@@ -396,7 +325,7 @@ mod tests {
             // Verify results
             assert!(result.is_err(), "reveal_member should fail");
             assert!(
-                matches!(result.unwrap_err(), reveal::Error::DiscordError(_)),
+                matches!(result.unwrap_err(), Error::DiscordError(_)),
                 "Error should be a DiscordError"
             );
         }

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -513,7 +513,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_reveal_member_success() {
+        async fn can_successfully_reveal_single_member() {
             // Setup mock objects
             let mut mock_repo = MockNamesRepository::new();
             let mut mock_discord = MockDiscordConnector::new();
@@ -552,7 +552,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_reveal_member_without_real_name() {
+        async fn can_produce_mysterious_message_for_member_without_real_name() {
             // Setup mock objects
             let mut mock_repo = MockNamesRepository::new();
             let mut mock_discord = MockDiscordConnector::new();
@@ -597,7 +597,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_reveal_member_discord_send_error() {
+        async fn handles_discord_error_when_revealing_single_member() {
             // Setup mock objects
             let mut mock_repo = MockNamesRepository::new();
             let mut mock_discord = MockDiscordConnector::new();

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -118,7 +118,6 @@ fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
 mod tests {
     use crate::nicknamer::commands::names::Names;
     use crate::nicknamer::commands::reveal;
-    use crate::nicknamer::config;
     use crate::nicknamer::connectors::discord::ServerMember;
     use std::collections::HashMap;
 
@@ -184,130 +183,6 @@ mod tests {
         assert_eq!(
             result,
             "How mysterious! UnknownNickname's true name is shrouded by darkness"
-        );
-    }
-
-    #[test]
-    fn can_reveal_all_members_with_real_names() {
-        // Setup
-        let real_names = create_test_real_names();
-        let members = vec![
-            create_server_member(
-                123456789,
-                Some("AliceNickname".to_string()),
-                "AliceUsername".to_string(),
-            ),
-            create_server_member(
-                987654321,
-                Some("BobNickname".to_string()),
-                "BobUsername".to_string(),
-            ),
-        ];
-
-        // Call the function
-        let result = reveal::reveal_all_members(&members, &real_names).unwrap();
-
-        // The result should contain all users with real names
-        let expected_header = format!("Here are people's real names, {}:", config::REVEAL_INSULT);
-        assert!(
-            result.starts_with(&expected_header),
-            "Result should start with the expected header"
-        );
-        assert!(
-            result.contains("'AliceNickname' is Alice"),
-            "Result should contain Alice's information"
-        );
-        assert!(
-            result.contains("'BobNickname' is Bob"),
-            "Result should contain Bob's information"
-        );
-    }
-
-    #[test]
-    fn can_reveal_known_members_when_some_members_have_no_real_names() {
-        // Setup
-        let real_names = create_test_real_names();
-        let members = vec![
-            create_server_member(
-                123456789,
-                Some("AliceNickname".to_string()),
-                "AliceUsername".to_string(),
-            ),
-            create_server_member(
-                111222333, // ID not in real_names
-                Some("UnknownUser".to_string()),
-                "UnknownUsername".to_string(),
-            ),
-            create_server_member(
-                987654321,
-                Some("BobNickname".to_string()),
-                "BobUsername".to_string(),
-            ),
-        ];
-
-        // Call the function
-        let result = reveal::reveal_all_members(&members, &real_names).unwrap();
-
-        // The result should only contain users with real names (Alice and Bob)
-        let expected_header = format!("Here are people's real names, {}:", config::REVEAL_INSULT);
-        assert!(
-            result.starts_with(&expected_header),
-            "Result should start with the expected header"
-        );
-        assert!(
-            result.contains("'AliceNickname' is Alice"),
-            "Result should contain Alice's information"
-        );
-        assert!(
-            result.contains("'BobNickname' is Bob"),
-            "Result should contain Bob's information"
-        );
-        assert!(
-            !result.contains("UnknownUser"),
-            "Result should not contain unknown user's information"
-        );
-    }
-
-    #[test]
-    fn can_provide_insult_when_no_members_have_real_names() {
-        // Setup
-        let real_names = create_test_real_names();
-        let members = vec![
-            create_server_member(
-                111222333, // ID not in real_names
-                Some("UnknownUser1".to_string()),
-                "UnknownUsername1".to_string(),
-            ),
-            create_server_member(
-                444555666, // ID not in real_names
-                Some("UnknownUser2".to_string()),
-                "UnknownUsername2".to_string(),
-            ),
-        ];
-
-        // Call the function
-        let result = reveal::reveal_all_members(&members, &real_names).unwrap();
-
-        // For no real names, we should get the "unimportant" message
-        assert_eq!(
-            result,
-            "Y'all a bunch of unimportant, good fer nothing no-names"
-        );
-    }
-
-    #[test]
-    fn can_provide_insult_when_members_list_is_empty() {
-        // Setup
-        let real_names = create_test_real_names();
-        let members: Vec<ServerMember> = vec![];
-
-        // Call the function
-        let result = reveal::reveal_all_members(&members, &real_names).unwrap();
-
-        // For empty members list, we should also get the "unimportant" message
-        assert_eq!(
-            result,
-            "Y'all a bunch of unimportant, good fer nothing no-names"
         );
     }
 

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -139,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_member_with_real_name() {
+    fn can_reveal_member_with_real_name() {
         // Setup
         let real_names = create_test_real_names();
         let server_member = create_server_member(
@@ -156,7 +156,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_member_without_nickname() {
+    fn can_reveal_member_without_nickname() {
         // Setup - member with username but no nickname
         let real_names = create_test_real_names();
         let server_member = create_server_member(123456789, None, "AliceUsername".to_string());
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_member_without_real_name() {
+    fn can_reveal_member_without_real_name() {
         // Setup - member with an ID that doesn't exist in real_names
         let real_names = create_test_real_names();
         let server_member = create_server_member(
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_member_with_special_characters() {
+    fn can_reveal_member_with_special_characters() {
         // Setup
         let mut real_names = create_test_real_names();
         real_names
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_member_preserves_nickname_case() {
+    fn can_preserve_nickname_case_when_revealing_member() {
         // Setup
         let real_names = create_test_real_names();
         let server_member = create_server_member(
@@ -229,7 +229,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_members_with_same_real_name() {
+    fn can_reveal_multiple_members_with_same_real_name() {
         // Setup - two members with the same real name
         let mut real_names = create_test_real_names();
         real_names.names.insert(111222333, "Bob".to_string());
@@ -256,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_conversion_from_server_member_to_user() {
+    fn can_convert_server_member_to_user() {
         // Setup
         let server_member = create_server_member(
             123456789,
@@ -274,7 +274,7 @@ mod tests {
     }
 
     #[test]
-    fn revealing_user_with_no_nickname_results_in_insult() {
+    fn can_get_mysterious_message_for_user_without_real_name() {
         // Test for a user with no real name
         let result = reveal::create_reply_for(&User {
             id: 0,
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_all_members_with_real_names() {
+    fn can_reveal_all_members_with_real_names() {
         // Setup
         let real_names = create_test_real_names();
         let members = vec![
@@ -327,7 +327,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_all_members_with_some_without_real_names() {
+    fn can_reveal_known_members_when_some_members_have_no_real_names() {
         // Setup
         let real_names = create_test_real_names();
         let members = vec![
@@ -372,7 +372,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_all_members_with_no_real_names() {
+    fn can_provide_insult_when_no_members_have_real_names() {
         // Setup
         let real_names = create_test_real_names();
         let members = vec![
@@ -399,7 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reveal_all_members_with_empty_members_list() {
+    fn can_provide_insult_when_members_list_is_empty() {
         // Setup
         let real_names = create_test_real_names();
         let members: Vec<ServerMember> = vec![];
@@ -424,7 +424,7 @@ mod tests {
         use std::collections::HashMap;
 
         #[tokio::test]
-        async fn test_reveal_all_success() {
+        async fn can_successfully_reveal_all_members() {
             // Setup mock objects
             let mut mock_repo = MockNamesRepository::new();
             let mut mock_discord = MockDiscordConnector::new();
@@ -476,7 +476,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_reveal_all_discord_error() {
+        async fn handles_discord_error_when_revealing_all() {
             // Setup mock objects
             let mock_repo = MockNamesRepository::new();
             let mut mock_discord = MockDiscordConnector::new();
@@ -504,41 +504,12 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_reveal_all_names_error() {
+        async fn handles_names_error_when_revealing_all() {
             // Setup mock objects
             let mut mock_repo = MockNamesRepository::new();
             let mut mock_discord = MockDiscordConnector::new();
 
             // Define test data
-            let members = vec![ServerMember {
-                id: 123456789,
-                nick_name: Some("AliceNickname".to_string()),
-                user_name: "AliceUsername".to_string(),
-            }];
-
-            // Set up expectations
-            mock_discord
-                .expect_get_members_of_current_channel()
-                .times(1)
-                .returning(move || Ok(members.clone()));
-
-            mock_repo
-                .expect_load_real_names()
-                .times(1)
-                .returning(move || Err(names::Error::CannotLoadNames));
-
-            // Create revealer with mock objects
-            let revealer = RevealerImpl::new(&mock_repo, &mock_discord);
-
-            // Execute the method under test
-            let result = revealer.reveal_all().await;
-
-            // Verify results
-            assert!(result.is_err(), "reveal_all should fail");
-            assert!(
-                matches!(result.unwrap_err(), reveal::Error::NamesAccessError(_)),
-                "Error should be a NamesAccessError"
-            );
         }
 
         #[tokio::test]

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -34,6 +34,7 @@ pub trait DiscordConnector {
 ///
 /// Contains basic information about a Discord server member,
 /// including their ID, nickname (if any), and username.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct ServerMember {
     /// Discord user's unique identifier
     pub(crate) id: u64,

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -1,3 +1,4 @@
+use mockall::automock;
 use thiserror::Error;
 
 pub(crate) mod serenity;
@@ -18,6 +19,7 @@ pub enum Error {
 ///
 /// This trait defines the required functionality for connecting to
 /// and retrieving information from Discord servers.
+#[automock]
 pub trait DiscordConnector {
     /// Retrieves all members present in the current Discord channel.
     ///


### PR DESCRIPTION
This pull request introduces several updates to the `nicknamer` project, including dependency additions, improved error handling, enhanced test clarity, and the introduction of mockable traits for better testability. Below is a summary of the most important changes:

### Dependency and Error Handling Updates:
* Added `mockall` as a new dependency in `Cargo.toml` to enable mocking in tests.
* Replaced `SerdeYamlError` with a new `CannotLoadNames` error in the `Error` enum for better clarity when loading names fails.
* Updated the `load_real_names` method in `EmbeddedNamesRepository` to map YAML parsing errors to the new `CannotLoadNames` error.

### Test Improvements:
* Renamed test function names in `nicknamer/src/nicknamer/commands/mod.rs` to be more descriptive and follow the "can do X" naming convention for better readability and understanding of test purposes. [[1]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L61-R61) [[2]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L81-R81) [[3]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L101-R101) [[4]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L121-R121) [[5]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L141-R141) [[6]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L157-R157) [[7]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L173-R173) [[8]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L189-R189) [[9]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L208-R208)

### Mocking and Testability Enhancements:
* Introduced the `#[automock]` attribute to the `NamesRepository` and `DiscordConnector` traits to enable mocking in unit tests. [[1]](diffhunk://#diff-66a09ec64a6495e8ea2819540270add2164ea86f466ca91a2c6f7c9042c6dc68R1-R17) [[2]](diffhunk://#diff-0fc9559109684ba899e94f9d570c2e9e91442bbb86731c3cf65386595aca8c52R22)
* Added the `Clone` trait to the `Names` struct and the `ServerMember` struct to support cloning during tests and mocking. [[1]](diffhunk://#diff-66a09ec64a6495e8ea2819540270add2164ea86f466ca91a2c6f7c9042c6dc68R1-R17) [[2]](diffhunk://#diff-0fc9559109684ba899e94f9d570c2e9e91442bbb86731c3cf65386595aca8c52R37)