### PR TITLE
fix: update reveal command to disclose tagged member's name without access check

### DIFF
--- a/nicknamer/src/main.rs
+++ b/nicknamer/src/main.rs
@@ -51,7 +51,7 @@ async fn nick(
 ///
 /// Specifically, I'll reveal the names of members that can access this channel
 ///
-/// You can also tag another member and I'll only reveal the real name of that person
+/// You can also tag another member and I'll reveal the name of that person, regardless of whether they can access this channel or not
 #[poise::command(prefix_command)]
 async fn reveal(
     ctx: Context<'_>,


### PR DESCRIPTION
This pull request includes a minor clarification to the documentation comment in the `nicknamer/src/main.rs` file. The change specifies that the `reveal` command will disclose the name of a tagged member regardless of their channel access.