### PR TITLE
feat: reveal now tags code monkeys

### DIFF
--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -10,14 +10,14 @@ pub(crate) type Reply = String;
 #[derive(Debug, PartialEq, Default)]
 pub struct User {
     pub id: u64,
-    pub display_name: String,
+    pub nick_name: String,
     pub real_name: Option<String>,
 }
 impl From<discord::ServerMember> for User {
     fn from(discord_member: discord::ServerMember) -> Self {
         Self {
             id: discord_member.id,
-            display_name: discord_member
+            nick_name: discord_member
                 .nick_name
                 .clone()
                 .unwrap_or_else(|| discord_member.user_name.clone()),
@@ -30,7 +30,7 @@ impl From<&discord::ServerMember> for User {
     fn from(discord_member: &discord::ServerMember) -> Self {
         Self {
             id: discord_member.id,
-            display_name: discord_member
+            nick_name: discord_member
                 .nick_name
                 .clone()
                 .unwrap_or_else(|| discord_member.user_name.clone()),
@@ -42,9 +42,9 @@ impl From<&discord::ServerMember> for User {
 impl Display for User {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(real_name) = &self.real_name {
-            write!(f, "'{}' is {}", self.display_name, real_name)
+            write!(f, "'{}' is {}", self.nick_name, real_name)
         } else {
-            write!(f, "'{}' has no real name available", self.display_name)
+            write!(f, "'{}' has no real name available", self.nick_name)
         }
     }
 }
@@ -73,7 +73,7 @@ mod tests {
 
         // Assert
         assert_eq!(user.id, 12345);
-        assert_eq!(user.display_name, "NickName");
+        assert_eq!(user.nick_name, "NickName");
         assert_eq!(user.real_name, Some("Real Name".into()));
     }
 
@@ -93,7 +93,7 @@ mod tests {
 
         // Assert
         assert_eq!(user.id, 67890);
-        assert_eq!(user.display_name, "UserName"); // Should fall back to username
+        assert_eq!(user.nick_name, "UserName"); // Should fall back to username
         assert_eq!(user.real_name, Some("Real Name".into()));
     }
 
@@ -113,7 +113,7 @@ mod tests {
 
         // Assert
         assert_eq!(user.id, 13579);
-        assert_eq!(user.display_name, ""); // Should use the empty nickname
+        assert_eq!(user.nick_name, ""); // Should use the empty nickname
         assert_eq!(user.real_name, Some("Real Name".into()));
     }
 
@@ -133,7 +133,7 @@ mod tests {
 
         // Assert
         assert_eq!(user.id, 24680);
-        assert_eq!(user.display_name, "SameName");
+        assert_eq!(user.nick_name, "SameName");
         assert_eq!(user.real_name, Some("Real Name".into()));
     }
 
@@ -142,7 +142,7 @@ mod tests {
         // Arrange
         let user = User {
             id: 12345,
-            display_name: "DisplayName".to_string(),
+            nick_name: "DisplayName".to_string(),
             real_name: Some("RealName".to_string()),
         };
 
@@ -158,7 +158,7 @@ mod tests {
         // Arrange
         let user = User {
             id: 12345,
-            display_name: "DisplayName".to_string(),
+            nick_name: "DisplayName".to_string(),
             real_name: None,
         };
 
@@ -174,7 +174,7 @@ mod tests {
         // Arrange
         let user = User {
             id: 12345,
-            display_name: "".to_string(),
+            nick_name: "".to_string(),
             real_name: Some("RealName".to_string()),
         };
 
@@ -190,7 +190,7 @@ mod tests {
         // Arrange
         let user = User {
             id: 12345,
-            display_name: "Name\"With'Quotes".to_string(),
+            nick_name: "Name\"With'Quotes".to_string(),
             real_name: Some("Real\"Name'With'Quotes".to_string()),
         };
 
@@ -209,7 +209,7 @@ mod tests {
         // Arrange - edge case with empty string (not None) for real_name
         let user = User {
             id: 12345,
-            display_name: "DisplayName".to_string(),
+            nick_name: "DisplayName".to_string(),
             real_name: Some("".to_string()),
         };
 

--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -39,17 +39,31 @@ impl From<&discord::ServerMember> for User {
 impl Display for User {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(real_name) = &self.real_name {
-            if let Some(nick_name) = &self.nick_name {
-                write!(f, "'{}' is {}", nick_name, real_name)
-            } else {
-                Ok(())
-            }
+            self.display_user_with_real_name(f, real_name)
         } else {
-            if let Some(nick_name) = &self.nick_name {
-                write!(f, "{} aka '{}'", self.user_name, nick_name)
-            } else {
-                Ok(())
-            }
+            self.display_user_without_real_name(f)
+        }
+    }
+}
+
+impl User {
+    fn display_user_with_real_name(
+        &self,
+        f: &mut Formatter,
+        real_name: &String,
+    ) -> std::fmt::Result {
+        if let Some(nick_name) = &self.nick_name {
+            write!(f, "'{}' is {}", nick_name, real_name)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn display_user_without_real_name(&self, f: &mut Formatter) -> std::fmt::Result {
+        if let Some(nick_name) = &self.nick_name {
+            write!(f, "{} aka '{}'", self.user_name, nick_name)
+        } else {
+            Ok(())
         }
     }
 }

--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -55,7 +55,7 @@ impl User {
         if let Some(nick_name) = &self.nick_name {
             write!(f, "'{}' is {}", nick_name, real_name)
         } else {
-            Ok(())
+            write!(f, "'{}' is {}", self.user_name, real_name)
         }
     }
 
@@ -63,7 +63,11 @@ impl User {
         if let Some(nick_name) = &self.nick_name {
             write!(f, "{} aka '{}'", self.user_name, nick_name)
         } else {
-            Ok(())
+            write!(
+                f,
+                "{} has neither a nickname nor a real name",
+                self.user_name
+            )
         }
     }
 }
@@ -242,5 +246,42 @@ mod tests {
 
         // Assert
         assert_eq!(display_string, "'DisplayName' is ");
+    }
+
+    #[test]
+    fn can_format_user_with_no_nickname_no_real_name() {
+        // Arrange
+        let user = User {
+            id: 12345,
+            user_name: "UserName".to_string(),
+            nick_name: None,
+            real_name: None,
+        };
+
+        // Act
+        let display_string = format!("{}", user);
+
+        // Assert
+        assert_eq!(
+            display_string,
+            "UserName has neither a nickname nor a real name"
+        );
+    }
+
+    #[test]
+    fn can_format_user_with_real_name_but_no_nickname() {
+        // Arrange
+        let user = User {
+            id: 12345,
+            user_name: "UserName".to_string(),
+            nick_name: None,
+            real_name: Some("RealName".to_string()),
+        };
+
+        // Act
+        let display_string = format!("{}", user);
+
+        // Assert
+        assert_eq!(display_string, "'UserName' is RealName");
     }
 }

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -119,8 +119,8 @@ fn create_reply_for_user_with_real_name(user: &User) -> Reply {
 }
 
 fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
-    let users_with_real_names = create_reply_for_users_with_real_names(users);
-    if users_with_real_names.is_empty() {
+    let reply_for_users_with_real_names = create_reply_for_users_with_real_names(users);
+    if reply_for_users_with_real_names.is_empty() {
         return Ok("Y'all a bunch of unimportant, good fer nothing no-names".to_string());
     }
 
@@ -128,7 +128,7 @@ fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
         "Here are people's real names, {}:
 {}",
         config::REVEAL_INSULT,
-        users_with_real_names.join("\n")
+        reply_for_users_with_real_names.join("\n")
     ))
 }
 

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -35,7 +35,7 @@ impl<'a, REPO: NamesRepository, DISCORD: DiscordConnector> Revealer
     for RevealerImpl<'a, REPO, DISCORD>
 {
     async fn reveal_all(&self) -> Result<(), Error> {
-        info!("Revealing nicknames for current channel members ...");
+        info!("Revealing real names for current channel members ...");
         let members = self
             .discord_connector
             .get_members_of_current_channel()

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -60,7 +60,7 @@ fn reveal_member(server_member: &ServerMember, real_names: &Names) -> Reply {
     let mut user: User = server_member.into();
     let real_name = real_names.names.get(&user_id).cloned();
     user.real_name = real_name;
-    create_reply_for_users_with_real_name(&user)
+    create_reply_for_user_with_real_name(&user)
 }
 
 fn reveal_all_members(members: &[ServerMember], real_names: &Names) -> Result<Reply, Error> {
@@ -80,42 +80,37 @@ fn reveal_all_members(members: &[ServerMember], real_names: &Names) -> Result<Re
     create_reply_for_all(&users)
 }
 
-/// Creates a reply message for users who have a real name.
+/// Creates a `Reply` for a user, ensuring the user has a real name.
 ///
 /// # Arguments
 ///
-/// * `user` - A reference to a `User` object. The `User` must have the `real_name`
-///   field set to `Some`, as creating a reply is only possible for users with a real name.
+/// * `user` - A reference to a `User` object for whom the reply will be created.
 ///
 /// # Returns
 ///
-/// * A `Reply` message created from the user's information.
+/// A `Reply` object based on the provided user's information.
 ///
 /// # Panics
 ///
-/// This function will panic if the `real_name` field of the `User` is `None`.
+/// This function will panic if the user does not have a real name (i.e.,
+/// `user.real_name` is `None`). The panic message is:
+/// `"You can't create a reply for a user without a real name"`.
 ///
-/// # Examples
+/// # Behavior
+///
+/// This function assumes that the `to_string` method has been implemented
+/// for the `User` type, and it is used to generate the content of the reply.
+///
+/// # Example
 ///
 /// ```
 /// let user = User {
-///     real_name: Some(String::from("John Doe")),
-///     // other fields...
+///     real_name: Some(String::from("Alice")),
+///     // Other fields...
 /// };
-/// let reply = create_reply_for_users_with_real_name(&user);
-/// println!("{}", reply);
+/// let reply = create_reply_for_user_with_real_name(&user);
 /// ```
-///
-/// If the `real_name` is `None`:
-///
-/// ```should_panic
-/// let user = User {
-///     real_name: None,
-///     // other fields...
-/// };
-/// let reply = create_reply_for_users_with_real_name(&user); // This will panic
-/// ```
-fn create_reply_for_users_with_real_name(user: &User) -> Reply {
+fn create_reply_for_user_with_real_name(user: &User) -> Reply {
     assert!(
         user.real_name.is_some(),
         "You can't create a reply for a user without a real name"
@@ -141,7 +136,7 @@ fn create_reply_for_users_with_real_names(users: &[User]) -> Vec<String> {
     users
         .into_iter()
         .filter(|user| user.real_name.is_some())
-        .map(|user| create_reply_for_users_with_real_name(user))
+        .map(|user| create_reply_for_user_with_real_name(user))
         .collect::<Vec<String>>()
 }
 

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -60,7 +60,11 @@ fn reveal_member(server_member: &ServerMember, real_names: &Names) -> Reply {
     let mut user: User = server_member.into();
     let real_name = real_names.names.get(&user_id).cloned();
     user.real_name = real_name;
-    create_reply_for_user_with_real_name(&user)
+    assert!(
+        user.real_name.is_some(),
+        "You can't create a reply for a user without a real name"
+    );
+    user.to_string()
 }
 
 fn reveal_all_members(members: &[ServerMember], real_names: &Names) -> Result<Reply, Error> {
@@ -80,49 +84,19 @@ fn reveal_all_members(members: &[ServerMember], real_names: &Names) -> Result<Re
     create_reply_for_all(&users)
 }
 
-/// Creates a `Reply` for a user, ensuring the user has a real name.
-///
-/// # Arguments
-///
-/// * `user` - A reference to a `User` object for whom the reply will be created.
-///
-/// # Returns
-///
-/// A `Reply` object based on the provided user's information.
-///
-/// # Panics
-///
-/// This function will panic if the user does not have a real name (i.e.,
-/// `user.real_name` is `None`). The panic message is:
-/// `"You can't create a reply for a user without a real name"`.
-///
-/// # Behavior
-///
-/// This function assumes that the `to_string` method has been implemented
-/// for the `User` type, and it is used to generate the content of the reply.
-///
-/// # Example
-///
-/// ```
-/// let user = User {
-///     real_name: Some(String::from("Alice")),
-///     // Other fields...
-/// };
-/// let reply = create_reply_for_user_with_real_name(&user);
-/// ```
-fn create_reply_for_user_with_real_name(user: &User) -> Reply {
-    assert!(
-        user.real_name.is_some(),
-        "You can't create a reply for a user without a real name"
-    );
-    user.to_string()
-}
-
 fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
-    let reply_for_users_with_real_names = create_reply_for_users_with_real_names(users);
-    if reply_for_users_with_real_names.is_empty() {
+    let users_with_real_names = users
+        .into_iter()
+        .filter(|user| user.real_name.is_some())
+        .collect::<Vec<&User>>();
+    if users_with_real_names.is_empty() {
         return Ok("Y'all a bunch of unimportant, good fer nothing no-names".to_string());
     }
+
+    let reply_for_users_with_real_names = users
+        .into_iter()
+        .map(|user| user.to_string())
+        .collect::<Vec<String>>();
 
     Ok(format!(
         "Here are people's real names, {}:
@@ -130,14 +104,6 @@ fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
         config::REVEAL_INSULT,
         reply_for_users_with_real_names.join("\n")
     ))
-}
-
-fn create_reply_for_users_with_real_names(users: &[User]) -> Vec<String> {
-    users
-        .into_iter()
-        .filter(|user| user.real_name.is_some())
-        .map(|user| create_reply_for_user_with_real_name(user))
-        .collect::<Vec<String>>()
 }
 
 #[cfg(test)]

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -91,8 +91,8 @@ fn create_reply_for(user: &User) -> Result<Reply, Error> {
 }
 
 fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
-    let users = create_reply_for_users_with_real_names(users);
-    if users.is_empty() {
+    let users_with_real_names = create_reply_for_users_with_real_names(users);
+    if users_with_real_names.is_empty() {
         return Ok("Y'all a bunch of unimportant, good fer nothing no-names".to_string());
     }
 
@@ -100,7 +100,7 @@ fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
         "Here are people's real names, {}:
 {}",
         config::REVEAL_INSULT,
-        users.join("\n")
+        users_with_real_names.join("\n")
     ))
 }
 

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -91,17 +91,7 @@ fn create_reply_for(user: &User) -> Result<Reply, Error> {
 }
 
 fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
-    let users = users
-        .into_iter()
-        .filter(|user| user.real_name.is_some())
-        .filter_map(|user| match create_reply_for(user) {
-            Ok(reply) => Some(reply),
-            Err(err) => {
-                info!("Error creating reply for user: {}", err);
-                None
-            }
-        })
-        .collect::<Vec<String>>();
+    let users = create_reply_for_users_with_real_names(users);
     if users.is_empty() {
         return Ok("Y'all a bunch of unimportant, good fer nothing no-names".to_string());
     }
@@ -112,6 +102,20 @@ fn create_reply_for_all(users: &[User]) -> Result<Reply, Error> {
         config::REVEAL_INSULT,
         users.join("\n")
     ))
+}
+
+fn create_reply_for_users_with_real_names(users: &[User]) -> Vec<String> {
+    users
+        .into_iter()
+        .filter(|user| user.real_name.is_some())
+        .filter_map(|user| match create_reply_for(user) {
+            Ok(reply) => Some(reply),
+            Err(err) => {
+                info!("Error creating reply for user: {}", err);
+                None
+            }
+        })
+        .collect::<Vec<String>>()
 }
 
 #[cfg(test)]

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -62,8 +62,8 @@ impl<'a, REPO: NamesRepository, DISCORD: DiscordConnector> RevealerImpl<'a, REPO
     ) -> Result<(), Error> {
         self.reveal_users_with_real_name(members, real_names)
             .await?;
-        // self.reveal_users_without_real_name(members, real_names)
-        //     .await?;
+        self.reveal_users_without_real_name(members, real_names)
+            .await?;
         Ok(())
     }
 
@@ -146,7 +146,7 @@ fn create_reply_for_users_with_real_names(users: &[User]) -> Reply {
         return "Y'all a bunch of unimportant, good fer nothing no-names".to_string();
     }
 
-    let reply_for_users_with_real_names = users
+    let reply = users
         .into_iter()
         .map(|user| user.to_string())
         .collect::<Vec<String>>();
@@ -155,7 +155,7 @@ fn create_reply_for_users_with_real_names(users: &[User]) -> Reply {
         "Here are people's real names, {}:
 {}",
         config::REVEAL_INSULT,
-        reply_for_users_with_real_names.join("\n")
+        reply.join("\n")
     )
 }
 
@@ -163,7 +163,12 @@ fn create_reply_for_users_without_real_names(users: &[User]) -> Reply {
     if users.is_empty() {
         return "".into();
     }
-    todo!()
+    let reply = users
+        .into_iter()
+        .map(|user| user.to_string())
+        .collect::<Vec<String>>();
+
+    format!("Hey {}", config::CODE_MONKEYS_ROLE_NAME)
 }
 
 #[cfg(test)]

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -33,7 +33,7 @@ pub trait DiscordConnector {
     async fn get_members_of_current_channel(&self) -> Result<Vec<ServerMember>, Error>;
     /// Sends a reply to the person that invoked the prefix command
     async fn send_reply(&self, message: &str) -> Result<(), Error>;
-    async fn get_role_by_name(&self, name: &str) -> Result<Box<dyn Mentionable>, Error>;
+    async fn get_role_by_name(&self, name: &str) -> Result<Box<dyn Role>, Error>;
 }
 
 /// Represents a member of a Discord server.
@@ -50,6 +50,8 @@ pub struct ServerMember {
     pub(crate) user_name: String,
 }
 
-pub trait Mentionable {
+pub trait Mentionable: Send + Sync + 'static {
     fn mention(&self) -> String;
 }
+
+pub trait Role: Mentionable {}

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -13,6 +13,10 @@ pub enum Error {
     CannotFindMembersOfChannel,
     #[error("Cannot send reply")]
     CannotSendReply,
+    #[error("Cannot get guild")]
+    CannotGetGuild,
+    #[error("Cannot find role")]
+    CannotFindRole,
 }
 
 /// Trait for abstracting Discord server interactions.
@@ -27,7 +31,9 @@ pub trait DiscordConnector {
     ///
     /// * `Result<Vec<ServerMember>, Error>` - List of server members on success, or Discord error
     async fn get_members_of_current_channel(&self) -> Result<Vec<ServerMember>, Error>;
+    /// Sends a reply to the person that invoked the prefix command
     async fn send_reply(&self, message: &str) -> Result<(), Error>;
+    async fn get_role_by_name(&self, name: &str) -> Result<Box<dyn Mentionable>, Error>;
 }
 
 /// Represents a member of a Discord server.
@@ -42,4 +48,8 @@ pub struct ServerMember {
     pub(crate) nick_name: Option<String>,
     /// Discord username of the member
     pub(crate) user_name: String,
+}
+
+pub trait Mentionable {
+    fn mention(&self) -> String;
 }

--- a/nicknamer/src/nicknamer/connectors/discord/serenity.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/serenity.rs
@@ -7,10 +7,11 @@ use crate::nicknamer::connectors::discord::Error::{
     CannotFindChannel, CannotFindMembersOfChannel, CannotFindRole, CannotGetGuild, CannotSendReply,
     NotInServerChannel,
 };
-use crate::nicknamer::connectors::discord::{DiscordConnector, Error, Mentionable, ServerMember};
+use crate::nicknamer::connectors::discord::{
+    DiscordConnector, Error, Mentionable, Role, ServerMember,
+};
 use log::info;
 use poise::serenity_prelude as serenity;
-use poise::serenity_prelude::Role;
 
 /// Discord connector implementation using Serenity library.
 ///
@@ -57,7 +58,7 @@ impl DiscordConnector for SerenityDiscordConnector<'_> {
         Ok(())
     }
 
-    async fn get_role_by_name(&self, name: &str) -> Result<Box<dyn Mentionable>, Error> {
+    async fn get_role_by_name(&self, name: &str) -> Result<Box<dyn Role>, Error> {
         let Some(guild) = self.context.guild() else {
             return Err(CannotGetGuild);
         };
@@ -68,11 +69,13 @@ impl DiscordConnector for SerenityDiscordConnector<'_> {
     }
 }
 
-impl Mentionable for Role {
+impl Mentionable for serenity::Role {
     fn mention(&self) -> String {
         <Self as serenity::Mentionable>::mention(&self).to_string()
     }
 }
+
+impl Role for serenity::Role {}
 
 impl From<serenity::Member> for ServerMember {
     fn from(member: serenity::Member) -> Self {

--- a/nicknamer/src/nicknamer/connectors/discord/serenity.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/serenity.rs
@@ -4,11 +4,13 @@
 //! trait using the Serenity Discord library.
 
 use crate::nicknamer::connectors::discord::Error::{
-    CannotFindChannel, CannotFindMembersOfChannel, CannotSendReply, NotInServerChannel,
+    CannotFindChannel, CannotFindMembersOfChannel, CannotFindRole, CannotGetGuild, CannotSendReply,
+    NotInServerChannel,
 };
-use crate::nicknamer::connectors::discord::{DiscordConnector, Error, ServerMember};
+use crate::nicknamer::connectors::discord::{DiscordConnector, Error, Mentionable, ServerMember};
 use log::info;
 use poise::serenity_prelude as serenity;
+use poise::serenity_prelude::Role;
 
 /// Discord connector implementation using Serenity library.
 ///
@@ -53,6 +55,22 @@ impl DiscordConnector for SerenityDiscordConnector<'_> {
             return Err(CannotSendReply);
         };
         Ok(())
+    }
+
+    async fn get_role_by_name(&self, name: &str) -> Result<Box<dyn Mentionable>, Error> {
+        let Some(guild) = self.context.guild() else {
+            return Err(CannotGetGuild);
+        };
+        let Some(role) = guild.role_by_name(name) else {
+            return Err(CannotFindRole);
+        };
+        Ok(Box::new(role.clone()))
+    }
+}
+
+impl Mentionable for Role {
+    fn mention(&self) -> String {
+        <Self as serenity::Mentionable>::mention(&self).to_string()
     }
 }
 


### PR DESCRIPTION
This pull request refactors the `User` struct and improves the handling of user names, nicknames, and real names in the `nicknamer` module. It also enhances the `RevealerImpl` logic for revealing user information and updates the corresponding tests. Below are the key changes grouped by theme:

### Refactoring the `User` Struct
* Replaced the `display_name` field in the `User` struct with `user_name` and `nick_name`, where `nick_name` is now an `Option<String>` to better represent the presence or absence of a nickname. (`nicknamer/src/nicknamer/commands/mod.rs`, [nicknamer/src/nicknamer/commands/mod.rsL13-R22](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L13-R22))
* Updated the `Display` implementation for `User` to handle cases with or without `nick_name` and `real_name`, delegating logic to two new helper methods: `display_user_with_real_name` and `display_user_without_real_name`. (`nicknamer/src/nicknamer/commands/mod.rs`, [nicknamer/src/nicknamer/commands/mod.rsL45-R70](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L45-R70))

### Enhancements to `RevealerImpl`
* Refactored `RevealerImpl` to split the logic for revealing members into two methods: `reveal_users_with_real_name` and `reveal_users_without_real_name`, improving readability and modularity. (`nicknamer/src/nicknamer/commands/reveal.rs`, [[1]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L38-R123) [[2]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L78-R209)
* Added support for mentioning a specific role (e.g., `@CodeMonkeys`) when notifying about users without real names. (`nicknamer/src/nicknamer/commands/reveal.rs`, [nicknamer/src/nicknamer/commands/reveal.rsL78-R209](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L78-R209))

### Testing Updates
* Updated test cases to reflect the changes in the `User` struct, ensuring tests now validate `nick_name` instead of `display_name`. (`nicknamer/src/nicknamer/commands/mod.rs`, [[1]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L76-R99) [[2]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L96-R119) [[3]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L116-R139) [[4]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L136-R159) [[5]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L145-R169) [[6]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L161-R203) [[7]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L193-R220) [[8]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167L212-R240) [[9]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167R250-R286)
* Added new tests for edge cases, such as formatting a `User` with no nickname or real name. (`nicknamer/src/nicknamer/commands/mod.rs`, [nicknamer/src/nicknamer/commands/mod.rsR250-R286](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167R250-R286))
* Enhanced `RevealerImpl` tests to handle Discord errors and ensure proper behavior when revealing members. (`nicknamer/src/nicknamer/commands/reveal.rs`, [[1]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L247-R336) [[2]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L259-R350) [[3]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L272-R361)

### Minor Improvements
* Renamed generic type parameter `REPO` to `NAMES` in `RevealerImpl` for better clarity. (`nicknamer/src/nicknamer/commands/reveal.rs`, [nicknamer/src/nicknamer/commands/reveal.rsL25-R26](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L25-R26))
* Added a mock implementation for `Role` to support testing of role mentions. (`nicknamer/src/nicknamer/commands/reveal.rs`, [nicknamer/src/nicknamer/commands/reveal.rsL78-R209](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L78-R209))

These changes enhance the maintainability and functionality of the `nicknamer` module while ensuring robust test coverage.