### PR TITLE
build: update tokio feature flag and remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,15 +1922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "skeptic"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,9 +2175,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/nicknamer/Cargo.toml
+++ b/nicknamer/Cargo.toml
@@ -9,7 +9,7 @@ log4rs = { version = "1.3.0", features = ["console_appender"] }
 poise = "0.6.1"
 serde = "1.0.219"
 serde_yml = "0.0.12"
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.44.2", features = ["rt-multi-thread"] }
 anyhow = "1.0.98"
 thiserror = "2.0.12"
 mockall = "0.13.1"


### PR DESCRIPTION
This pull request includes a small change to the `nicknamer/Cargo.toml` file. The change updates the `tokio` dependency to use the `rt-multi-thread` feature instead of the `full` feature.