### PR TITLE
docs: Add doc

### DIFF
--- a/nicknamer/src/nicknamer/commands/names/mod.rs
+++ b/nicknamer/src/nicknamer/commands/names/mod.rs
@@ -1,29 +1,74 @@
+//! Names module for handling user real name data.
+//!
+//! This module provides functionality for loading, storing, and accessing mappings
+//! between Discord user IDs and their real names. It includes:
+//! - Data structures for representing collections of user real names
+//! - A repository trait for loading name data
+//! - An implementation that loads names from an embedded YAML file
+//!
+//! The module supports deserializing name data from YAML format and provides
+//! error handling for failed loading operations.
+
 use crate::nicknamer::commands::names::Error::CannotLoadNames;
 use log::info;
 use mockall::automock;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// Errors that can occur during name operations.
+///
+/// These errors represent failures that might occur when
+/// loading or processing user real name data.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Indicates a failure to load the names data, typically from YAML parsing
     #[error("Failed to load names")]
     CannotLoadNames,
 }
+
+/// Collection of user real names indexed by Discord user IDs.
+///
+/// This structure stores a mapping of Discord user IDs to their corresponding
+/// real names, allowing for quick lookups. It is designed to be serialized
+/// to and deserialized from YAML format.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Names {
+    /// Mapping of Discord user IDs to real names
     pub(crate) names: std::collections::HashMap<u64, String>,
 }
 
+/// Trait defining operations for accessing user real name data.
+///
+/// Implementations of this trait provide mechanisms for loading
+/// real name data from various sources.
 #[automock]
 pub trait NamesRepository {
+    /// Loads the real names collection from the repository.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Names, Error>` - The loaded names on success, or an error if loading fails
     async fn load_real_names(&self) -> Result<Names, Error>;
 }
 
+/// Repository implementation that loads names from an embedded YAML file.
+///
+/// This implementation includes the names data directly in the binary,
+/// allowing for deployment without external data files.
 pub struct EmbeddedNamesRepository {
+    /// Contents of the embedded YAML file containing real names
     embedded_names: &'static str,
 }
 
 impl EmbeddedNamesRepository {
+    /// Creates a new instance of the embedded names repository.
+    ///
+    /// This constructor includes the contents of the real_names.yml file
+    /// directly in the binary at compile time.
+    ///
+    /// # Returns
+    ///
+    /// A new EmbeddedNamesRepository instance
     pub(crate) fn new() -> Self {
         Self {
             embedded_names: include_str!("real_names.yml"),
@@ -32,6 +77,14 @@ impl EmbeddedNamesRepository {
 }
 
 impl NamesRepository for EmbeddedNamesRepository {
+    /// Loads real names from the embedded YAML data.
+    ///
+    /// Deserializes the embedded YAML string into a Names collection.
+    /// Logs the number of names loaded for debugging purposes.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Names, Error>` - The loaded Names on success, or CannotLoadNames error on failure
     async fn load_real_names(&self) -> Result<Names, Error> {
         let names: Names = serde_yml::from_str(self.embedded_names).map_err(|_| CannotLoadNames)?;
         info!("Loaded {} names", names.names.len());

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -1,20 +1,41 @@
+//! Discord connectivity module for the nickname manager.
+//!
+//! This module provides abstractions for interacting with Discord, including:
+//! - Error types for Discord connectivity issues
+//! - Traits defining Discord server interaction capabilities
+//! - Data structures for representing Discord server members and roles
+//!
+//! The module is designed to be implementation-agnostic, allowing for different
+//! Discord client libraries to be used by implementing the `DiscordConnector` trait.
+//! A concrete implementation using the Serenity library is provided in the `serenity` submodule.
+
 use mockall::automock;
 use thiserror::Error;
 
 pub(crate) mod serenity;
 
+/// Errors that can occur during Discord connectivity operations.
+///
+/// These errors represent various failure modes when interacting with Discord,
+/// such as being unable to find channels, members, or send messages.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// The command was not executed in a server channel
     #[error("Not in a server channel")]
     NotInServerChannel,
+    /// Unable to find the specified Discord channel
     #[error("Cannot find channel")]
     CannotFindChannel,
+    /// Unable to retrieve the members of a channel
     #[error("Cannot find members of channel")]
     CannotFindMembersOfChannel,
+    /// Failed to send a reply message
     #[error("Cannot send reply")]
     CannotSendReply,
+    /// Failed to retrieve the guild (server) information
     #[error("Cannot get guild")]
     CannotGetGuild,
+    /// Unable to find the specified role
     #[error("Cannot find role")]
     CannotFindRole,
 }
@@ -33,6 +54,15 @@ pub trait DiscordConnector {
     async fn get_members_of_current_channel(&self) -> Result<Vec<ServerMember>, Error>;
     /// Sends a reply to the person that invoked the prefix command
     async fn send_reply(&self, message: &str) -> Result<(), Error>;
+    /// Looks up a role in the current guild by its name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the role to find
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Box<dyn Role>, Error>` - The role if found, or an error otherwise
     async fn get_role_by_name(&self, name: &str) -> Result<Box<dyn Role>, Error>;
 }
 
@@ -50,8 +80,22 @@ pub struct ServerMember {
     pub(crate) user_name: String,
 }
 
+/// Represents an entity that can be mentioned in Discord messages.
+///
+/// This trait is implemented by types that can be referenced in Discord
+/// messages using mentions (like @user or @role).
 pub trait Mentionable: Send + Sync + 'static {
+    /// Returns the string representation of a mention for this entity.
+    ///
+    /// # Returns
+    ///
+    /// The formatted mention string that can be included in Discord messages
     fn mention(&self) -> String;
 }
 
+/// Represents a Discord role.
+///
+/// This trait extends the `Mentionable` trait to specifically identify
+/// Discord role entities. Implementations should represent Discord roles
+/// with their associated permissions and properties.
 pub trait Role: Mentionable {}


### PR DESCRIPTION

This PR adds comprehensive documentation to the Discord connectivity and names modules. Key changes include:
- New module-level documentation and error type descriptions in the Discord connector.
- Added documentation for traits and repository implementation in the names commands module.
- Clarified the behavior of methods such as get_role_by_name and load_real_names.
