### PR TITLE
feat: check if user is a bot when revealing

### DIFF
--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -87,6 +87,7 @@ mod tests {
             id: 12345,
             nick_name: Some("NickName".to_string()),
             user_name: "UserName".to_string(),
+            is_bot: false,
         };
         let real_name = Some("Real Name".to_string());
 
@@ -107,6 +108,7 @@ mod tests {
             id: 67890,
             nick_name: None,
             user_name: "UserName".to_string(),
+            is_bot: false,
         };
         let real_name = Some("Real Name".to_string());
 
@@ -127,6 +129,7 @@ mod tests {
             id: 13579,
             nick_name: Some("".to_string()), // Empty nickname
             user_name: "UserName".to_string(),
+            is_bot: false,
         };
         let real_name = Some("Real Name".to_string());
 
@@ -147,6 +150,7 @@ mod tests {
             id: 24680,
             nick_name: Some("SameName".to_string()),
             user_name: "SameName".to_string(),
+            is_bot: false,
         };
         let real_name = Some("Real Name".to_string());
 

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -225,11 +225,13 @@ mod tests {
                     id: 123456789,
                     nick_name: Some("AliceNickname".to_string()),
                     user_name: "AliceUsername".to_string(),
+                    is_bot: false,
                 },
                 ServerMember {
                     id: 987654321,
                     nick_name: Some("BobNickname".to_string()),
                     user_name: "BobUsername".to_string(),
+                    is_bot: false,
                 },
             ];
 
@@ -304,6 +306,7 @@ mod tests {
                 id: 123456789,
                 nick_name: Some("AliceNickname".to_string()),
                 user_name: "AliceUsername".to_string(),
+                is_bot: false,
             };
 
             let mut names_map = HashMap::new();
@@ -343,6 +346,7 @@ mod tests {
                 id: 123456789,
                 nick_name: Some("AliceNickname".to_string()),
                 user_name: "AliceUsername".to_string(),
+                is_bot: false,
             };
 
             let mut names_map = HashMap::new();
@@ -386,11 +390,13 @@ mod tests {
                     id: 111111111, // ID not in real_names database
                     nick_name: Some("UnknownNick1".to_string()),
                     user_name: "UnknownUser1".to_string(),
+                    is_bot: false,
                 },
                 ServerMember {
                     id: 222222222, // ID not in real_names database
                     nick_name: Some("UnknownNick2".to_string()),
                     user_name: "UnknownUser2".to_string(),
+                    is_bot: false,
                 },
             ];
 

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -78,6 +78,8 @@ pub struct ServerMember {
     pub(crate) nick_name: Option<String>,
     /// Discord username of the member
     pub(crate) user_name: String,
+    /// Whether the member is a bot
+    pub(crate) is_bot: bool,
 }
 
 /// Represents an entity that can be mentioned in Discord messages.

--- a/nicknamer/src/nicknamer/connectors/discord/serenity.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/serenity.rs
@@ -83,6 +83,7 @@ impl From<serenity::Member> for ServerMember {
             id: member.user.id.get(),
             nick_name: member.nick.clone(),
             user_name: member.user.name.clone(),
+            is_bot: member.user.bot,
         }
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to handle bot users in the `nicknamer` application, ensuring that bots are excluded from certain operations and improving the robustness of the `Revealer` module. The changes include adding a new `is_bot` field to the `ServerMember` struct, updating logic to filter out bots, and expanding test coverage to validate these updates.

### Enhancements to `ServerMember`:

* Added an `is_bot` field to the `ServerMember` struct to indicate whether a member is a bot (`nicknamer/src/nicknamer/connectors/discord/mod.rs`).
* Updated the `From<serenity::Member>` implementation to populate the `is_bot` field based on the Discord API's data (`nicknamer/src/nicknamer/connectors/discord/serenity.rs`).

### Logic updates in `Revealer`:

* Modified the `reveal_member` function to handle bot users by returning a specific message if the member is a bot (`nicknamer/src/nicknamer/commands/reveal.rs`).
* Updated the `get_users_without_real_names` function to exclude bots from the list of users without real names (`nicknamer/src/nicknamer/commands/reveal.rs`).

### Test improvements:

* Added new test cases to ensure bot users are correctly filtered out and handled in various scenarios, including:
  - `reveal_all_should_filter_out_bot_users`
  - `reveal_all_with_all_bot_users_should_not_send_message`
  - `reveal_member_should_handle_bot_member`
  - `reveal_member_should_handle_member_without_real_name`
  - `reveal_member_should_handle_member_with_real_name`
  - `reveal_member_should_handle_names_repository_error` (`nicknamer/src/nicknamer/commands/reveal.rs`). [[1]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L297-R495) [[2]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L370-R589)
* Updated test data in `nicknamer/src/nicknamer/commands/mod.rs` to include the `is_bot` field for various test cases. [[1]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167R90) [[2]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167R111) [[3]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167R132) [[4]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167R153)

### Logging update:

* Improved the log message in `reveal_member` to clarify that it reveals the "real name" instead of the "nickname" (`nicknamer/src/nicknamer/commands/reveal.rs`).