### PR TITLE
refactor: don't load real names when revealing bots

### DIFF
--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -48,7 +48,7 @@ impl<'a, REPO: NamesRepository, DISCORD: DiscordConnector> Revealer
     async fn reveal_member(&self, member: &ServerMember) -> Result<(), Error> {
         info!("Revealing real name for {}", member.user_name);
         if member.is_bot {
-            self.reveal_bot_member(&member).await?;
+            self.reveal_bot_member(member).await?;
         } else {
             self.reveal_human_member(member).await?;
         }
@@ -66,7 +66,7 @@ impl<'a, REPO: NamesRepository, DISCORD: DiscordConnector> RevealerImpl<'a, REPO
 }
 
 impl<'a, REPO: NamesRepository, DISCORD: DiscordConnector> RevealerImpl<'a, REPO, DISCORD> {
-    async fn reveal_bot_member(&self, member: &&ServerMember) -> Result<(), Error> {
+    async fn reveal_bot_member(&self, member: &ServerMember) -> Result<(), Error> {
         let name_to_show = match &member.nick_name {
             Some(nick_name) => nick_name,
             None => &member.user_name,


### PR DESCRIPTION
This pull request refactors the `reveal_member` functionality in `nicknamer/src/nicknamer/commands/reveal.rs` to better handle bot members and simplifies the associated test cases. The most important changes include splitting the logic for handling bot and human members into separate methods, removing unnecessary repository calls for bot members, and updating the test cases to reflect these changes.

### Refactoring `reveal_member` functionality:
* The `reveal_member` method now delegates to `reveal_bot_member` or `reveal_human_member` based on whether the member is a bot. This improves code clarity and separation of concerns. (`[nicknamer/src/nicknamer/commands/reveal.rsR50-R79](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8R50-R79)`)
* Removed bot-specific logic from the `reveal_member` function and moved it into the new `reveal_bot_member` method. (`[nicknamer/src/nicknamer/commands/reveal.rsL111-L118](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L111-L118)`)

### Simplifications in test cases:
* Removed unnecessary mock repository expectations for bot-related test cases, as the repository is no longer queried for bot members. (`[[1]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L438-L444)`, `[[2]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L479-L485)`, `[[3]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L523-L529)`)
* Updated test cases to use immutable `mock_repo` instead of mutable, reflecting the reduced reliance on the repository. (`[[1]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L427-R442)`, `[[2]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L468-R476)`, `[[3]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L512-R513)`)