### PR TITLE
feat(commands): add `nick` command

### DIFF
--- a/nicknamer/src/main.rs
+++ b/nicknamer/src/main.rs
@@ -46,8 +46,7 @@ async fn nick(
 ) -> anyhow::Result<()> {
     let connector = SerenityDiscordConnector::new(ctx);
     let nick_service = NickServiceImpl::new(&connector);
-    let user: ServerMember = member.into();
-    nick_service.nick(user.id, &nickname).await?;
+    nick_service.nick(&member.into(), &nickname).await?;
     Ok(())
 }
 

--- a/nicknamer/src/main.rs
+++ b/nicknamer/src/main.rs
@@ -3,7 +3,7 @@ mod nicknamer;
 use self::nicknamer::commands::names::EmbeddedNamesRepository;
 use self::nicknamer::connectors::discord;
 use self::nicknamer::connectors::discord::serenity::{Context, SerenityDiscordConnector};
-use crate::nicknamer::commands;
+use crate::nicknamer::commands::nick::{NickService, NickServiceImpl};
 use crate::nicknamer::commands::reveal::{Revealer, RevealerImpl};
 use crate::nicknamer::connectors::discord::ServerMember;
 use log::{LevelFilter, info};
@@ -37,13 +37,17 @@ Type ~help command for more info on a command.",
     Ok(())
 }
 
-/// Routine responsible for 'nick' discord command.
+/// Changes the nickname for a member into a new one
 #[poise::command(prefix_command)]
 async fn nick(
-    _ctx: discord::serenity::Context<'_>,
-    member: serenity::Member,
+    ctx: Context<'_>,
+    #[description = "The specific member to reveal the name of"] member: Member,
+    #[description = "The new nickname to set"] nickname: String,
 ) -> anyhow::Result<()> {
-    commands::nick(member.user.id);
+    let connector = SerenityDiscordConnector::new(ctx);
+    let nick_service = NickServiceImpl::new(&connector);
+    let user: ServerMember = member.into();
+    nick_service.nick(user.id, &nickname).await?;
     Ok(())
 }
 
@@ -95,7 +99,7 @@ async fn main() {
 
     let framework = poise::Framework::<discord::serenity::Data, anyhow::Error>::builder()
         .options(poise::FrameworkOptions {
-            commands: vec![help(), ping(), reveal()],
+            commands: vec![help(), ping(), reveal(), nick()],
             prefix_options: poise::PrefixFrameworkOptions {
                 prefix: Some("~".into()),
                 ..Default::default()

--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -1,5 +1,4 @@
 use crate::nicknamer::connectors::discord;
-use poise::serenity_prelude as serenity;
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
 
@@ -74,9 +73,6 @@ impl User {
         }
     }
 }
-
-#[allow(dead_code)]
-pub fn nick(_user_id: serenity::UserId) {}
 
 #[cfg(test)]
 mod tests {

--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -1,9 +1,12 @@
 use crate::nicknamer::connectors::discord;
 use poise::serenity_prelude as serenity;
 use std::fmt::{Display, Formatter};
+use thiserror::Error;
 
 pub(crate) mod names;
 pub mod reveal;
+
+pub mod nick;
 
 pub(crate) type Reply = String;
 
@@ -288,4 +291,12 @@ mod tests {
         // Assert
         assert_eq!(display_string, "'UserName' is RealName");
     }
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Something went wrong with Discord")]
+    DiscordError(#[from] discord::Error),
+    #[error("Something went wrong getting people's names")]
+    NamesAccessError(#[from] names::Error),
 }

--- a/nicknamer/src/nicknamer/commands/nick.rs
+++ b/nicknamer/src/nicknamer/commands/nick.rs
@@ -23,3 +23,91 @@ impl<'a, DISCORD: DiscordConnector> NickService for NickServiceImpl<'a, DISCORD>
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nicknamer::connectors::discord::Error as DiscordError;
+    use crate::nicknamer::connectors::discord::MockDiscordConnector;
+    use mockall::predicate::*;
+
+    #[tokio::test]
+    async fn nick_service_calls_discord_connector() {
+        // Arrange
+        let mut mock_discord = MockDiscordConnector::new();
+        mock_discord
+            .expect_change_member_nick_name()
+            .with(eq(123456789), eq("NewNick"))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let service = NickServiceImpl::new(&mock_discord);
+
+        // Act
+        let result = service.nick(123456789, "NewNick").await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn nick_service_handles_discord_error() {
+        // Arrange
+        let mut mock_discord = MockDiscordConnector::new();
+        mock_discord
+            .expect_change_member_nick_name()
+            .times(1)
+            .returning(|_, _| Err(DiscordError::NotEnoughPermissions));
+
+        let service = NickServiceImpl::new(&mock_discord);
+
+        // Act
+        let result = service.nick(123456789, "NewNick").await;
+
+        // Assert
+        assert!(result.is_err());
+        match result {
+            Err(Error::DiscordError(_)) => (),
+            _ => panic!("Expected DiscordError, got different error type"),
+        }
+    }
+
+    #[tokio::test]
+    async fn nick_service_handles_empty_nickname() {
+        // Arrange
+        let mut mock_discord = MockDiscordConnector::new();
+        mock_discord
+            .expect_change_member_nick_name()
+            .with(eq(123456789), eq(""))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let service = NickServiceImpl::new(&mock_discord);
+
+        // Act
+        let result = service.nick(123456789, "").await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn nick_service_handles_long_nickname() {
+        // Arrange
+        let long_nickname = "A".repeat(100); // Some very long nickname
+        let mut mock_discord = MockDiscordConnector::new();
+        mock_discord
+            .expect_change_member_nick_name()
+            .with(eq(123456789), eq(String::from(long_nickname.as_str())))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let service = NickServiceImpl::new(&mock_discord);
+
+        // Act
+        let result = service.nick(123456789, &long_nickname).await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+}

--- a/nicknamer/src/nicknamer/commands/nick.rs
+++ b/nicknamer/src/nicknamer/commands/nick.rs
@@ -1,5 +1,25 @@
 use crate::nicknamer::commands::Error;
+use crate::nicknamer::connectors::discord::DiscordConnector;
 
-pub trait Nick {
-    async fn nick(&self, nick: &str) -> Result<(), Error>;
+pub trait NickService {
+    async fn nick(&self, user_id: u64, new_nick_name: &str) -> Result<(), Error>;
+}
+
+pub struct NickServiceImpl<'a, DISCORD: DiscordConnector> {
+    discord_connector: &'a DISCORD,
+}
+
+impl<'a, DISCORD: DiscordConnector> NickServiceImpl<'a, DISCORD> {
+    pub fn new(discord_connector: &'a DISCORD) -> Self {
+        Self { discord_connector }
+    }
+}
+
+impl<'a, DISCORD: DiscordConnector> NickService for NickServiceImpl<'a, DISCORD> {
+    async fn nick(&self, user_id: u64, new_nick_name: &str) -> Result<(), Error> {
+        self.discord_connector
+            .change_member_nick_name(user_id, new_nick_name)
+            .await?;
+        Ok(())
+    }
 }

--- a/nicknamer/src/nicknamer/commands/nick.rs
+++ b/nicknamer/src/nicknamer/commands/nick.rs
@@ -57,10 +57,22 @@ mod tests {
             .times(1)
             .returning(|_, _| Ok(()));
 
+        mock_discord
+            .expect_send_reply()
+            .times(1)
+            .returning(|_| Ok(()));
+
         let service = NickServiceImpl::new(&mock_discord);
 
+        let member = ServerMember {
+            id: 123456789,
+            nick_name: Some("OldNick".to_string()),
+            user_name: "UserName".to_string(),
+            is_bot: false,
+        };
+
         // Act
-        let result = service.nick(123456789, "NewNick").await;
+        let result = service.nick(&member, "NewNick").await;
 
         // Assert
         assert!(result.is_ok());
@@ -77,8 +89,15 @@ mod tests {
 
         let service = NickServiceImpl::new(&mock_discord);
 
+        let member = ServerMember {
+            id: 123456789,
+            nick_name: Some("OldNick".to_string()),
+            user_name: "UserName".to_string(),
+            is_bot: false,
+        };
+
         // Act
-        let result = service.nick(123456789, "NewNick").await;
+        let result = service.nick(&member, "NewNick").await;
 
         // Assert
         assert!(result.is_err());
@@ -98,10 +117,22 @@ mod tests {
             .times(1)
             .returning(|_, _| Ok(()));
 
+        mock_discord
+            .expect_send_reply()
+            .times(1)
+            .returning(|_| Ok(()));
+
         let service = NickServiceImpl::new(&mock_discord);
 
+        let member = ServerMember {
+            id: 123456789,
+            nick_name: Some("OldNick".to_string()),
+            user_name: "UserName".to_string(),
+            is_bot: false,
+        };
+
         // Act
-        let result = service.nick(123456789, "").await;
+        let result = service.nick(&member, "").await;
 
         // Assert
         assert!(result.is_ok());
@@ -118,10 +149,22 @@ mod tests {
             .times(1)
             .returning(|_, _| Ok(()));
 
+        mock_discord
+            .expect_send_reply()
+            .times(1)
+            .returning(|_| Ok(()));
+
         let service = NickServiceImpl::new(&mock_discord);
 
+        let member = ServerMember {
+            id: 123456789,
+            nick_name: Some("OldNick".to_string()),
+            user_name: "UserName".to_string(),
+            is_bot: false,
+        };
+
         // Act
-        let result = service.nick(123456789, &long_nickname).await;
+        let result = service.nick(&member, &long_nickname).await;
 
         // Assert
         assert!(result.is_ok());

--- a/nicknamer/src/nicknamer/commands/nick.rs
+++ b/nicknamer/src/nicknamer/commands/nick.rs
@@ -1,0 +1,5 @@
+use crate::nicknamer::commands::Error;
+
+pub trait Nick {
+    async fn nick(&self, nick: &str) -> Result<(), Error>;
+}

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -1,18 +1,9 @@
 use crate::nicknamer::commands::names::{Names, NamesRepository};
-use crate::nicknamer::commands::{Reply, User, names};
+use crate::nicknamer::commands::{Error, Reply, User};
 use crate::nicknamer::config;
-use crate::nicknamer::connectors::discord;
 use crate::nicknamer::connectors::discord::{DiscordConnector, Role, ServerMember};
 use log::info;
-use thiserror::Error;
 
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("Something went wrong with Discord")]
-    DiscordError(#[from] discord::Error),
-    #[error("Something went wrong getting people's names")]
-    NamesAccessError(#[from] names::Error),
-}
 pub trait Revealer {
     async fn reveal_all(&self) -> Result<(), Error>;
     async fn reveal_member(&self, member: &ServerMember) -> Result<(), Error>;

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -38,6 +38,8 @@ pub enum Error {
     /// Unable to find the specified role
     #[error("Cannot find role")]
     CannotFindRole,
+    #[error("Not enough permissions")]
+    NotEnoughPermissions,
 }
 
 /// Trait for abstracting Discord server interactions.
@@ -64,6 +66,12 @@ pub trait DiscordConnector {
     ///
     /// * `Result<Box<dyn Role>, Error>` - The role if found, or an error otherwise
     async fn get_role_by_name(&self, name: &str) -> Result<Box<dyn Role>, Error>;
+
+    async fn change_member_nick_name(
+        &self,
+        member_id: u64,
+        new_nick_name: &str,
+    ) -> Result<(), Error>;
 }
 
 /// Represents a member of a Discord server.

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -67,10 +67,10 @@ pub trait DiscordConnector {
     /// * `Result<Box<dyn Role>, Error>` - The role if found, or an error otherwise
     async fn get_role_by_name(&self, name: &str) -> Result<Box<dyn Role>, Error>;
 
-    async fn change_member_nick_name(
-        &self,
+    async fn change_member_nick_name<'connector, 'name>(
+        &'connector self,
         member_id: u64,
-        new_nick_name: &str,
+        new_nick_name: &'name str,
     ) -> Result<(), Error>;
 }
 

--- a/nicknamer/src/nicknamer/connectors/discord/serenity.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/serenity.rs
@@ -5,13 +5,14 @@
 
 use crate::nicknamer::connectors::discord::Error::{
     CannotFindChannel, CannotFindMembersOfChannel, CannotFindRole, CannotGetGuild, CannotSendReply,
-    NotInServerChannel,
+    NotEnoughPermissions, NotInServerChannel,
 };
 use crate::nicknamer::connectors::discord::{
     DiscordConnector, Error, Mentionable, Role, ServerMember,
 };
 use log::info;
 use poise::serenity_prelude as serenity;
+use poise::serenity_prelude::EditMember;
 
 /// Discord connector implementation using Serenity library.
 ///
@@ -66,6 +67,21 @@ impl DiscordConnector for SerenityDiscordConnector<'_> {
             return Err(CannotFindRole);
         };
         Ok(Box::new(role.clone()))
+    }
+
+    async fn change_member_nick_name(
+        &self,
+        member_id: u64,
+        new_nick_name: &str,
+    ) -> Result<(), Error> {
+        let Some(guild) = self.context.guild_id() else {
+            return Err(CannotGetGuild);
+        };
+        let builder = EditMember::new().nickname(new_nick_name);
+        let Ok(_member) = guild.edit_member(self.context, member_id, builder).await else {
+            return Err(NotEnoughPermissions);
+        };
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This pull request introduces a new `nick` command to the `nicknamer` module, allowing Discord users to change a member's nickname. It includes the implementation of the `NickService` and integrates it with the Serenity-based Discord connector. Additionally, it refactors error handling and enhances test coverage.

### New Feature: `nick` Command
* Added a new `nick` command to change a member's nickname via the `NickService`. The command is registered in the bot's framework and includes parameters for the member and the new nickname. (`nicknamer/src/main.rs`, [[1]](diffhunk://#diff-6810ec788f9819cb9595e7694605d57126d1d04599e9bc7ea38c974b1f287cb9L40-R49) [[2]](diffhunk://#diff-6810ec788f9819cb9595e7694605d57126d1d04599e9bc7ea38c974b1f287cb9L98-R101)

### Implementation of `NickService`
* Introduced the `NickService` trait and its implementation, `NickServiceImpl`, which handles nickname changes using the `DiscordConnector`. It provides detailed feedback messages for successful nickname changes. (`nicknamer/src/nicknamer/commands/nick.rs`, [nicknamer/src/nicknamer/commands/nick.rsR1-R274](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR1-R274))

### Integration with Discord Connector
* Extended the `DiscordConnector` trait with a new method, `change_member_nick_name`, to interact with Discord's API for modifying member nicknames. This method is implemented in the `SerenityDiscordConnector`. (`nicknamer/src/nicknamer/connectors/discord/mod.rs`, [[1]](diffhunk://#diff-0fc9559109684ba899e94f9d570c2e9e91442bbb86731c3cf65386595aca8c52R69-R74); `nicknamer/src/nicknamer/connectors/discord/serenity.rs`, [[2]](diffhunk://#diff-a86388bf829f6f919f195866679d6879b76ff1df0b7d7bb9bd6232f9e57f758cR71-R85)

### Refactoring and Error Handling
* Centralized error definitions in the `commands` module, removing duplicate error definitions from the `reveal` module. Added a new `NotEnoughPermissions` error to handle insufficient permissions for nickname changes. (`nicknamer/src/nicknamer/commands/mod.rs`, [[1]](diffhunk://#diff-9bc8eadab0152fc067b47017a129fbe19c8fb2c85711e28db7ef6d491c573167R291-R298); `nicknamer/src/nicknamer/commands/reveal.rs`, [[2]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8L2-L15); `nicknamer/src/nicknamer/connectors/discord/mod.rs`, [[3]](diffhunk://#diff-0fc9559109684ba899e94f9d570c2e9e91442bbb86731c3cf65386595aca8c52R41-R42)

### Test Coverage
* Added comprehensive unit tests for the `NickServiceImpl` to validate its behavior under various scenarios, including successful nickname changes, handling of Discord errors, and edge cases like empty or long nicknames. (`nicknamer/src/nicknamer/commands/nick.rs`, [nicknamer/src/nicknamer/commands/nick.rsR1-R274](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR1-R274))… handling