### PR TITLE
feat: admonish people for renaming guild owner

### DIFF
--- a/nicknamer/src/nicknamer/commands/nick.rs
+++ b/nicknamer/src/nicknamer/commands/nick.rs
@@ -96,6 +96,9 @@ mod tests {
     use crate::nicknamer::connectors::discord::MockDiscordConnector;
     use mockall::predicate::*;
 
+    // Guild owner ID constant for tests
+    const GUILD_OWNER_ID: u64 = 987654321;
+
     #[tokio::test]
     async fn nick_service_calls_discord_connector() {
         // Arrange
@@ -103,7 +106,7 @@ mod tests {
         mock_discord
             .expect_get_guild_owner_id()
             .times(1)
-            .returning(|| Ok(987654321)); // Different from member ID
+            .returning(|| Ok(GUILD_OWNER_ID)); // Different from member ID
 
         mock_discord
             .expect_change_member_nick_name()
@@ -135,13 +138,12 @@ mod tests {
     #[tokio::test]
     async fn nick_service_prevents_renaming_server_owner() {
         // Arrange
-        let owner_id = 123456789;
         let mut mock_discord = MockDiscordConnector::new();
 
         mock_discord
             .expect_get_guild_owner_id()
             .times(1)
-            .returning(move || Ok(owner_id));
+            .returning(|| Ok(GUILD_OWNER_ID));
 
         // Expect admonish message to be sent
         mock_discord
@@ -158,7 +160,7 @@ mod tests {
         let service = NickServiceImpl::new(&mock_discord);
 
         let member = ServerMember {
-            id: owner_id, // Same as owner_id
+            id: GUILD_OWNER_ID, // Same as owner_id
             nick_name: Some("OwnerNick".to_string()),
             user_name: "OwnerName".to_string(),
             is_bot: false,
@@ -203,13 +205,12 @@ mod tests {
     #[tokio::test]
     async fn nick_service_handles_admonish_error() {
         // Arrange
-        let owner_id = 123456789;
         let mut mock_discord = MockDiscordConnector::new();
 
         mock_discord
             .expect_get_guild_owner_id()
             .times(1)
-            .returning(move || Ok(owner_id));
+            .returning(|| Ok(GUILD_OWNER_ID));
 
         // Simulate error when sending admonishment
         mock_discord
@@ -220,7 +221,7 @@ mod tests {
         let service = NickServiceImpl::new(&mock_discord);
 
         let member = ServerMember {
-            id: owner_id,
+            id: GUILD_OWNER_ID,
             nick_name: Some("OwnerNick".to_string()),
             user_name: "OwnerName".to_string(),
             is_bot: false,
@@ -244,7 +245,7 @@ mod tests {
         mock_discord
             .expect_get_guild_owner_id()
             .times(1)
-            .returning(|| Ok(987654321)); // Different from member ID
+            .returning(|| Ok(GUILD_OWNER_ID)); // Different from member ID
 
         mock_discord
             .expect_change_member_nick_name()
@@ -278,7 +279,7 @@ mod tests {
         mock_discord
             .expect_get_guild_owner_id()
             .times(1)
-            .returning(|| Ok(987654321)); // Different from member ID
+            .returning(|| Ok(GUILD_OWNER_ID)); // Different from member ID
 
         mock_discord
             .expect_change_member_nick_name()
@@ -315,7 +316,7 @@ mod tests {
         mock_discord
             .expect_get_guild_owner_id()
             .times(1)
-            .returning(|| Ok(987654321)); // Different from member ID
+            .returning(|| Ok(GUILD_OWNER_ID)); // Different from member ID
 
         mock_discord
             .expect_change_member_nick_name()
@@ -351,7 +352,7 @@ mod tests {
         mock_discord
             .expect_get_guild_owner_id()
             .times(1)
-            .returning(|| Ok(987654321)); // Different from member ID
+            .returning(|| Ok(GUILD_OWNER_ID)); // Different from member ID
 
         mock_discord
             .expect_change_member_nick_name()
@@ -389,7 +390,7 @@ mod tests {
         mock_discord
             .expect_get_guild_owner_id()
             .times(1)
-            .returning(|| Ok(987654321)); // Different from member ID
+            .returning(|| Ok(GUILD_OWNER_ID)); // Different from member ID
 
         mock_discord
             .expect_change_member_nick_name()
@@ -429,7 +430,7 @@ mod tests {
         mock_discord
             .expect_get_guild_owner_id()
             .times(1)
-            .returning(|| Ok(987654321)); // Different from member ID
+            .returning(|| Ok(GUILD_OWNER_ID)); // Different from member ID
 
         mock_discord
             .expect_change_member_nick_name()

--- a/nicknamer/src/nicknamer/commands/nick.rs
+++ b/nicknamer/src/nicknamer/commands/nick.rs
@@ -38,7 +38,7 @@ impl<'a, DISCORD: DiscordConnector> NickServiceImpl<'a, DISCORD> {
 impl<'a, DISCORD: DiscordConnector> NickServiceImpl<'a, DISCORD> {
     async fn change_member_nick_name(
         &self,
-        member: &&ServerMember,
+        member: &ServerMember,
         new_nick_name: &str,
     ) -> Result<(), Error> {
         self.discord_connector

--- a/nicknamer/src/nicknamer/commands/nick.rs
+++ b/nicknamer/src/nicknamer/commands/nick.rs
@@ -22,20 +22,45 @@ impl<'a, DISCORD: DiscordConnector> NickService for NickServiceImpl<'a, DISCORD>
             .await?;
         match &member.nick_name {
             Some(nick_name) => {
-                let reply = format!(
-                    "Changed {}'s nickname from '{}' to '{}'",
-                    member.user_name, nick_name, new_nick_name
-                );
-                self.discord_connector.send_reply(&reply).await?;
+                self.send_reply_for_member_with_nick_name(member, new_nick_name, nick_name)
+                    .await?
             }
             None => {
-                let reply = format!(
-                    "{} has been christened with the name {}!",
-                    member.user_name, new_nick_name
-                );
-                self.discord_connector.send_reply(&reply).await?;
+                self.send_reply_for_member_without_nick_name(member, new_nick_name)
+                    .await?
             }
         }
+        Ok(())
+    }
+}
+
+impl<'a, DISCORD: DiscordConnector> NickServiceImpl<'a, DISCORD> {
+    async fn send_reply_for_member_without_nick_name(
+        &self,
+        member: &ServerMember,
+        new_nick_name: &str,
+    ) -> Result<(), Error> {
+        let reply = format!(
+            "{} has been christened with the name {}!",
+            member.user_name, new_nick_name
+        );
+        self.discord_connector.send_reply(&reply).await?;
+        Ok(())
+    }
+}
+
+impl<'a, DISCORD: DiscordConnector> NickServiceImpl<'a, DISCORD> {
+    async fn send_reply_for_member_with_nick_name(
+        &self,
+        member: &ServerMember,
+        new_nick_name: &str,
+        nick_name: &String,
+    ) -> Result<(), Error> {
+        let reply = format!(
+            "Changed {}'s nickname from '{}' to '{}'",
+            member.user_name, nick_name, new_nick_name
+        );
+        self.discord_connector.send_reply(&reply).await?;
         Ok(())
     }
 }

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -72,6 +72,8 @@ pub trait DiscordConnector {
         member_id: u64,
         new_nick_name: &'name str,
     ) -> Result<(), Error>;
+
+    async fn get_guild_owner_id(&self) -> Result<u64, Error>;
 }
 
 /// Represents a member of a Discord server.

--- a/nicknamer/src/nicknamer/connectors/discord/serenity.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/serenity.rs
@@ -85,7 +85,10 @@ impl DiscordConnector for SerenityDiscordConnector<'_> {
     }
 
     async fn get_guild_owner_id(&self) -> Result<u64, Error> {
-        todo!()
+        let Some(guild) = self.context.guild() else {
+            return Err(CannotGetGuild);
+        };
+        Ok(guild.owner_id.get())
     }
 }
 

--- a/nicknamer/src/nicknamer/connectors/discord/serenity.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/serenity.rs
@@ -83,6 +83,10 @@ impl DiscordConnector for SerenityDiscordConnector<'_> {
         };
         Ok(())
     }
+
+    async fn get_guild_owner_id(&self) -> Result<u64, Error> {
+        todo!()
+    }
 }
 
 impl Mentionable for serenity::Role {


### PR DESCRIPTION
This pull request introduces functionality to prevent renaming the server owner in the `NickServiceImpl` and adds comprehensive test cases to ensure the behavior is correct. It also extends the `DiscordConnector` trait and its implementation to support fetching the server owner ID.

### Feature Enhancements:
* **Prevent Renaming Server Owner**: Added logic in `NickServiceImpl` to check if the member being renamed is the server owner. If so, an admonishment message is sent instead of renaming. (`nicknamer/src/nicknamer/commands/nick.rs`, [nicknamer/src/nicknamer/commands/nick.rsR20-R87](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR20-R87))
* **New Helper Methods**: Introduced helper methods `admonish_for_violating_party_guidelines`, `change_member_nick_name`, `send_reply_for_member_with_nick_name`, and `send_reply_for_member_without_nick_name` to improve code readability and modularity. (`nicknamer/src/nicknamer/commands/nick.rs`, [nicknamer/src/nicknamer/commands/nick.rsR20-R87](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR20-R87))

### Testing Improvements:
* **New Test Cases**:
  - [`nick_service_prevents_renaming_server_owner`](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR138-R249): Verifies that the server owner cannot be renamed and the correct admonishment message is sent.
  - [`nick_service_handles_guild_owner_id_error`](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR138-R249): Ensures proper error handling when fetching the server owner ID fails.
  - [`nick_service_handles_admonish_error`](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR138-R249): Tests error handling when sending the admonishment message fails.
* **Updated Existing Tests**: Modified existing tests to include expectations for `get_guild_owner_id` calls to align with the new behavior. (`nicknamer/src/nicknamer/commands/nick.rs`, [[1]](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR99-R110) [[2]](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR279-R283) [[3]](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR316-R320) [[4]](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR352-R356) [[5]](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR390-R394) [[6]](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR430-R434)

### Connector Enhancements:
* **`DiscordConnector` Trait**: Added a new `get_guild_owner_id` method to fetch the server owner ID. (`nicknamer/src/nicknamer/connectors/discord/mod.rs`, [nicknamer/src/nicknamer/connectors/discord/mod.rsR75-R76](diffhunk://#diff-0fc9559109684ba899e94f9d570c2e9e91442bbb86731c3cf65386595aca8c52R75-R76))
* **Serenity Implementation**: Implemented the `get_guild_owner_id` method for `SerenityDiscordConnector` to retrieve the owner ID from the guild context. (`nicknamer/src/nicknamer/connectors/discord/serenity.rs`, [nicknamer/src/nicknamer/connectors/discord/serenity.rsR86-R92](diffhunk://#diff-a86388bf829f6f919f195866679d6879b76ff1df0b7d7bb9bd6232f9e57f758cR86-R92))