### PR TITLE
feat: add extra text for rogue members

### DIFF
--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -87,6 +87,7 @@ mod tests {
             nick_name: Some("NickName".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@12345>".to_string(),
         };
         let real_name = Some("Real Name".to_string());
 
@@ -108,6 +109,7 @@ mod tests {
             nick_name: None,
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@67890>".to_string(),
         };
         let real_name = Some("Real Name".to_string());
 
@@ -129,6 +131,7 @@ mod tests {
             nick_name: Some("".to_string()), // Empty nickname
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@13579>".to_string(),
         };
         let real_name = Some("Real Name".to_string());
 
@@ -150,6 +153,7 @@ mod tests {
             nick_name: Some("SameName".to_string()),
             user_name: "SameName".to_string(),
             is_bot: false,
+            mention: "<@24680>".to_string(),
         };
         let real_name = Some("Real Name".to_string());
 

--- a/nicknamer/src/nicknamer/commands/nick.rs
+++ b/nicknamer/src/nicknamer/commands/nick.rs
@@ -66,8 +66,9 @@ impl<'a, DISCORD: DiscordConnector> NickServiceImpl<'a, DISCORD> {
                             .get_role_by_name(config::CODE_MONKEYS_ROLE_NAME)
                             .await?;
                         format!(
-                            "Some devilry restricts my power. {} please investigate the rogue member",
-                            role_to_mention.mention()
+                            "Some devilry restricts my power. {} please investigate the rogue member {}",
+                            role_to_mention.mention(),
+                            member.mention
                         )
                     }
                     err => format!("You fool! You messed it up!: {}", err),
@@ -343,10 +344,10 @@ mod tests {
             .times(1)
             .returning(|_| Ok(Box::new(TestRole)));
 
-        // Expect send_reply to succeed with the proper message
+        // Expect send_reply to succeed with the proper message including member mention
         mock_discord
             .expect_send_reply()
-            .with(eq("Some devilry restricts my power. @Code Monkeys please investigate the rogue member"))
+            .with(eq("Some devilry restricts my power. @Code Monkeys please investigate the rogue member <@123456789>"))
             .times(1)
             .returning(|_| Ok(()));
 

--- a/nicknamer/src/nicknamer/commands/nick.rs
+++ b/nicknamer/src/nicknamer/commands/nick.rs
@@ -147,6 +147,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@123456789>".to_string(),
         };
 
         // Act
@@ -185,6 +186,7 @@ mod tests {
             nick_name: Some("OwnerNick".to_string()),
             user_name: "OwnerName".to_string(),
             is_bot: false,
+            mention: format!("<@{}>", GUILD_OWNER_ID),
         };
 
         // Act
@@ -210,6 +212,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: format!("<@{}>", GUILD_OWNER_ID),
         };
 
         // Act
@@ -246,6 +249,7 @@ mod tests {
             nick_name: Some("OwnerNick".to_string()),
             user_name: "OwnerName".to_string(),
             is_bot: false,
+            mention: format!("<@{}>", GUILD_OWNER_ID),
         };
 
         // Act
@@ -304,6 +308,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@123456789>".to_string(),
         };
 
         // Act
@@ -352,6 +357,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@123456789>".to_string(),
         };
 
         // Act
@@ -389,6 +395,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@123456789>".to_string(),
         };
 
         // Act
@@ -429,6 +436,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@123456789>".to_string(),
         };
 
         // Act
@@ -466,6 +474,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@123456789>".to_string(),
         };
 
         // Act
@@ -504,6 +513,7 @@ mod tests {
             nick_name: None, // No previous nickname
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@123456789>".to_string(),
         };
 
         // Act
@@ -540,6 +550,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@123456789>".to_string(),
         };
 
         // Act
@@ -583,6 +594,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: "<@123456789>".to_string(),
         };
 
         // Act
@@ -621,6 +633,7 @@ mod tests {
             nick_name: Some("OldNick".to_string()),
             user_name: "UserName".to_string(),
             is_bot: false,
+            mention: format!("<@{}>", 123456789),
         };
 
         // Act

--- a/nicknamer/src/nicknamer/commands/reveal.rs
+++ b/nicknamer/src/nicknamer/commands/reveal.rs
@@ -240,12 +240,14 @@ mod tests {
                     nick_name: Some("AliceNickname".to_string()),
                     user_name: "AliceUsername".to_string(),
                     is_bot: false,
+                    mention: "<@123456789>".to_string(),
                 },
                 ServerMember {
                     id: 987654321,
                     nick_name: Some("BobNickname".to_string()),
                     user_name: "BobUsername".to_string(),
                     is_bot: false,
+                    mention: "<@987654321>".to_string(),
                 },
             ];
 
@@ -322,12 +324,14 @@ mod tests {
                     nick_name: Some("HumanUser".to_string()),
                     user_name: "HumanUser".to_string(),
                     is_bot: false,
+                    mention: "<@111111111>".to_string(),
                 },
                 ServerMember {
                     id: 222222222,
                     nick_name: Some("BotUser".to_string()),
                     user_name: "BotUser".to_string(),
                     is_bot: true, // This is a bot
+                    mention: "<@222222222>".to_string(),
                 },
             ];
 
@@ -389,12 +393,14 @@ mod tests {
                     nick_name: Some("BotUser1".to_string()),
                     user_name: "BotUser1".to_string(),
                     is_bot: true,
+                    mention: "<@111111111>".to_string(),
                 },
                 ServerMember {
                     id: 222222222,
                     nick_name: Some("BotUser2".to_string()),
                     user_name: "BotUser2".to_string(),
                     is_bot: true,
+                    mention: "<@222222222>".to_string(),
                 },
             ];
 
@@ -439,6 +445,7 @@ mod tests {
                 nick_name: Some("BotNick".to_string()),
                 user_name: "BotUser".to_string(),
                 is_bot: true,
+                mention: "<@111111111>".to_string(),
             };
 
             // Check that the correct message is sent via Discord
@@ -473,6 +480,7 @@ mod tests {
                 nick_name: None,
                 user_name: "BotUserName".to_string(),
                 is_bot: true,
+                mention: "<@222222222>".to_string(),
             };
 
             // Check that the correct message is sent via Discord
@@ -510,6 +518,7 @@ mod tests {
                 nick_name: Some("ErrorBot".to_string()),
                 user_name: "ErrorBot".to_string(),
                 is_bot: true,
+                mention: "<@333333333>".to_string(),
             };
 
             // Discord connector returns an error when trying to send reply
@@ -547,6 +556,7 @@ mod tests {
                 nick_name: Some("NickName".to_string()),
                 user_name: "UserName".to_string(),
                 is_bot: false,
+                mention: "<@111111111>".to_string(),
             };
 
             // Empty names database
@@ -592,6 +602,7 @@ mod tests {
                 nick_name: Some("NickName".to_string()),
                 user_name: "UserName".to_string(),
                 is_bot: false,
+                mention: "<@111111111>".to_string(),
             };
 
             // Names database with the user's real name
@@ -637,6 +648,7 @@ mod tests {
                 nick_name: Some("NickName".to_string()),
                 user_name: "UserName".to_string(),
                 is_bot: false,
+                mention: format!("<@{}>", 111111111),
             };
 
             // Set up expectations - repository returns an error

--- a/nicknamer/src/nicknamer/connectors/discord/mod.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/mod.rs
@@ -90,6 +90,7 @@ pub struct ServerMember {
     pub(crate) user_name: String,
     /// Whether the member is a bot
     pub(crate) is_bot: bool,
+    pub(crate) mention: String,
 }
 
 /// Represents an entity that can be mentioned in Discord messages.

--- a/nicknamer/src/nicknamer/connectors/discord/serenity.rs
+++ b/nicknamer/src/nicknamer/connectors/discord/serenity.rs
@@ -13,6 +13,7 @@ use crate::nicknamer::connectors::discord::{
 use log::info;
 use poise::serenity_prelude as serenity;
 use poise::serenity_prelude::EditMember;
+use poise::serenity_prelude::Mentionable as poise_Mentionable;
 
 /// Discord connector implementation using Serenity library.
 ///
@@ -107,6 +108,7 @@ impl From<serenity::Member> for ServerMember {
             nick_name: member.nick.clone(),
             user_name: member.user.name.clone(),
             is_bot: member.user.bot,
+            mention: member.mention().to_string(),
         }
     }
 }


### PR DESCRIPTION
This pull request introduces the `mention` field to the `ServerMember` struct and updates related functionality across the codebase to support member mentions in Discord messages. The changes include updates to the `ServerMember` struct, test cases, and message formatting logic.

### Core Feature Addition:
* [`nicknamer/src/nicknamer/connectors/discord/mod.rs`](diffhunk://#diff-0fc9559109684ba899e94f9d570c2e9e91442bbb86731c3cf65386595aca8c52R93): Added a new `mention` field to the `ServerMember` struct to store the mention string for each member.
* [`nicknamer/src/nicknamer/connectors/discord/serenity.rs`](diffhunk://#diff-a86388bf829f6f919f195866679d6879b76ff1df0b7d7bb9bd6232f9e57f758cR111): Updated the `From<serenity::Member>` implementation to populate the `mention` field using the Serenity library's `mention()` method.

### Updates to Messaging Logic:
* [`nicknamer/src/nicknamer/commands/nick.rs`](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbL69-R71): Modified the message formatting in the `NickServiceImpl` implementation to include the `mention` field when notifying about rogue members.

### Test Case Enhancements:
* [`nicknamer/src/nicknamer/commands/nick.rs`](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR151): Updated multiple test cases to include the `mention` field in `ServerMember` instances. This ensures that the new functionality is properly tested. [[1]](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR151) [[2]](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbL341-R350) [[3]](diffhunk://#diff-2c71e90167e7eae94d304bb825b0c713aa36be7f36119b14cd9ec052612c1ecbR637) and others)
* [`nicknamer/src/nicknamer/commands/reveal.rs`](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8R243-R250): Added the `mention` field to `ServerMember` instances in test cases for the `reveal` command. [[1]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8R243-R250) [[2]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8R327-R334) [[3]](diffhunk://#diff-43dfe81505031c7411a23ba0ac37bc5989eb9a60a3c8e2f0203d3ab6d6b3f4b8R651)

### Dependency Updates:
* [`nicknamer/src/nicknamer/connectors/discord/serenity.rs`](diffhunk://#diff-a86388bf829f6f919f195866679d6879b76ff1df0b7d7bb9bd6232f9e57f758cR16): Imported the `Mentionable` trait from Serenity to support the new `mention` field.