### PR TITLE
feat: clean url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "clearurls"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e291c00af89ac0a5b400d9ba46a682e38015ae3cd8926dbbe85b3b864d550be3"
+dependencies = [
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1173,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1334,8 @@ name = "nicknamer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clearurls",
+ "linkify",
  "log",
  "log4rs",
  "mockall",

--- a/nicknamer/Cargo.toml
+++ b/nicknamer/Cargo.toml
@@ -13,3 +13,5 @@ tokio = { version = "1.45.0", features = ["rt-multi-thread"] }
 anyhow = "1.0.98"
 thiserror = "2.0.12"
 mockall = "0.13.1"
+linkify = "0.10.0"
+clearurls = "0.0.4"

--- a/nicknamer/src/nicknamer/commands/clean.rs
+++ b/nicknamer/src/nicknamer/commands/clean.rs
@@ -7,6 +7,11 @@ pub trait UrlCleaner {
     fn clean_message(&mut self, msg: &str) -> String;
 }
 
+struct CleanedMessage {
+    message: String,
+    cleaned_urls: Vec<(String, String)>,
+}
+
 pub struct UrlCleanerImpl {
     link_finder: LinkFinder,
     cleaner: clearurls::UrlCleaner,

--- a/nicknamer/src/nicknamer/commands/clean.rs
+++ b/nicknamer/src/nicknamer/commands/clean.rs
@@ -1,0 +1,32 @@
+use linkify::{LinkFinder, LinkKind};
+use log::error;
+
+pub trait UrlCleaner {
+    fn clean_url(&mut self, msg: &str) -> String;
+}
+
+pub struct UrlCleanerImpl {
+    link_finder: LinkFinder,
+    cleaner: clearurls::UrlCleaner,
+}
+
+impl UrlCleanerImpl {
+    pub fn new() -> Self {
+        Self {
+            link_finder: LinkFinder::new(),
+            cleaner: clearurls::UrlCleaner::from_embedded_rules().unwrap(),
+        }
+    }
+}
+
+impl UrlCleaner for UrlCleanerImpl {
+    fn clean_url(&mut self, msg: &str) -> String {
+        let finder = &mut self.link_finder;
+        for link in finder.kinds(&[LinkKind::Url]).links(msg) {
+            let Ok(cleaned) = self.cleaner.clear_single_url_str(link.as_str()) else {
+                error!("Failed to clean url: {}", link.as_str());
+            };
+        }
+        todo!();
+    }
+}

--- a/nicknamer/src/nicknamer/commands/clean.rs
+++ b/nicknamer/src/nicknamer/commands/clean.rs
@@ -20,3 +20,125 @@ impl UrlCleanerImpl {
         }
     }
 }
+
+impl UrlCleaner for UrlCleanerImpl {
+    fn clean_message(&mut self, msg: &str) -> String {
+        let mut result = msg.to_string();
+
+        // Find all links in the message
+        let links: Vec<_> = self.link_finder.links(msg).collect();
+
+        // If no links found, return the original message
+        if links.is_empty() {
+            return result;
+        }
+
+        // Process each link
+        for link in links {
+            let original_url = link.as_str();
+
+            // Clean the URL using the clearurls crate's functionality
+            if let Ok(cleaned_url) = self.cleaner.clear_single_url_str(original_url) {
+                // Convert Cow<str> to String for comparison
+                let cleaned_url_str = cleaned_url.into_owned();
+
+                // Replace the original URL with the cleaned one if they differ
+                if original_url != cleaned_url_str {
+                    result = result.replace(original_url, &cleaned_url_str);
+                }
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::*;
+    use mockall::*;
+
+    // Create a mock for the UrlCleaner trait
+    mock! {
+        UrlCleaner {}
+        impl UrlCleaner for UrlCleaner {
+            fn clean_message(&mut self, msg: &str) -> String;
+        }
+    }
+
+    #[test]
+    fn test_clean_message_with_no_urls() {
+        // Arrange
+        let mut cleaner = UrlCleanerImpl::new();
+        let message = "This is a message with no URLs";
+
+        // Act
+        let result = cleaner.clean_message(message);
+
+        // Assert
+        assert_eq!(result, message);
+    }
+
+    #[test]
+    fn test_clean_message_with_empty_message() {
+        // Arrange
+        let mut cleaner = UrlCleanerImpl::new();
+        let message = "";
+
+        // Act
+        let result = cleaner.clean_message(message);
+
+        // Assert
+        assert_eq!(result, message);
+    }
+
+    #[test]
+    fn test_clean_message_with_url_that_needs_cleaning() {
+        // Arrange
+        let mut cleaner = UrlCleanerImpl::new();
+        let message =
+            "Check out this link: https://example.com/page?utm_source=test&utm_medium=email";
+
+        // We'll mock the behavior of clear_single_url_str
+        // Since we can't easily mock the clearurls crate, we'll test the integration
+        // by verifying that the URL is different after cleaning
+
+        // Act
+        let result = cleaner.clean_message(message);
+
+        // Assert
+        assert_ne!(result, message);
+        assert!(result.contains("https://example.com/page"));
+        assert!(!result.contains("utm_source=test"));
+    }
+
+    #[test]
+    fn test_clean_message_with_url_that_doesnt_need_cleaning() {
+        // Arrange
+        let mut cleaner = UrlCleanerImpl::new();
+        let message = "Check out this link: https://example.com/page";
+
+        // Act
+        let result = cleaner.clean_message(message);
+
+        // Assert
+        assert_eq!(result, message);
+    }
+
+    #[test]
+    fn test_clean_message_with_multiple_urls() {
+        // Arrange
+        let mut cleaner = UrlCleanerImpl::new();
+        let message = "Check out these links: https://example.com/page?utm_source=test and https://another-example.com/page";
+
+        // Act
+        let result = cleaner.clean_message(message);
+
+        // Assert
+        assert_ne!(result, message);
+        assert!(result.contains("https://example.com/page"));
+        assert!(!result.contains("utm_source=test"));
+        assert!(result.contains("https://another-example.com/page"));
+    }
+}

--- a/nicknamer/src/nicknamer/commands/clean.rs
+++ b/nicknamer/src/nicknamer/commands/clean.rs
@@ -56,16 +56,6 @@ impl UrlCleaner for UrlCleanerImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockall::predicate::*;
-    use mockall::*;
-
-    // Create a mock for the UrlCleaner trait
-    mock! {
-        UrlCleaner {}
-        impl UrlCleaner for UrlCleaner {
-            fn clean_message(&mut self, msg: &str) -> String;
-        }
-    }
 
     #[test]
     fn test_clean_message_with_no_urls() {

--- a/nicknamer/src/nicknamer/commands/clean.rs
+++ b/nicknamer/src/nicknamer/commands/clean.rs
@@ -1,8 +1,10 @@
-use linkify::{LinkFinder, LinkKind};
-use log::error;
+use linkify::LinkFinder;
 
 pub trait UrlCleaner {
-    fn clean_url(&mut self, msg: &str) -> String;
+    /// Cleans a message by removing tracking parameters from URLs within it.
+    /// # Returns
+    /// The cleaned message.
+    fn clean_message(&mut self, msg: &str) -> String;
 }
 
 pub struct UrlCleanerImpl {
@@ -16,17 +18,5 @@ impl UrlCleanerImpl {
             link_finder: LinkFinder::new(),
             cleaner: clearurls::UrlCleaner::from_embedded_rules().unwrap(),
         }
-    }
-}
-
-impl UrlCleaner for UrlCleanerImpl {
-    fn clean_url(&mut self, msg: &str) -> String {
-        let finder = &mut self.link_finder;
-        for link in finder.kinds(&[LinkKind::Url]).links(msg) {
-            let Ok(cleaned) = self.cleaner.clear_single_url_str(link.as_str()) else {
-                error!("Failed to clean url: {}", link.as_str());
-            };
-        }
-        todo!();
     }
 }

--- a/nicknamer/src/nicknamer/commands/mod.rs
+++ b/nicknamer/src/nicknamer/commands/mod.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 pub(crate) mod names;
 pub mod reveal;
 
+mod clean;
 pub mod nick;
 
 pub(crate) type Reply = String;

--- a/nicknamer/src/nicknamer/config.rs
+++ b/nicknamer/src/nicknamer/config.rs
@@ -1,10 +1,9 @@
 pub const REVEAL_INSULT: &str = "ya dingus";
-#[allow(dead_code)]
 pub const CODE_MONKEYS_ROLE_NAME: &str = "Code Monkeys";
 #[allow(dead_code)]
 pub const URL_LENGTH_VIOLATION_FACTOR: u32 = 2;
 #[allow(dead_code)]
-pub const JAR_JAR_EMOJI_ID: u64 = 1061775549065855079;
+pub const URL_SHAME_EMOJI: u64 = 1309253735351976016;
 #[allow(dead_code)]
 pub const ZACH_USER_ID: u64 = 894692357457469471;
 #[allow(dead_code)]


### PR DESCRIPTION
This pull request introduces a new `UrlCleaner` feature to sanitize URLs in messages by removing tracking parameters, along with associated tests and configuration updates. It also includes minor changes to the project's structure and constants.

### New `UrlCleaner` Feature:
* Added a `UrlCleaner` trait and its implementation (`UrlCleanerImpl`) in `nicknamer/src/nicknamer/commands/clean.rs`. This feature uses the `linkify` and `clearurls` crates to identify and clean URLs in messages.
* Implemented unit tests for `UrlCleanerImpl` to verify its behavior with various input cases, such as messages with no URLs, URLs requiring cleaning, and multiple URLs.

### Dependency Updates:
* Added `linkify` and `clearurls` crates to `Cargo.toml` for URL parsing and cleaning functionality.

### Project Structure:
* Introduced a new `clean` module in `nicknamer/src/nicknamer/commands/mod.rs` to encapsulate the `UrlCleaner` feature.

### Configuration Changes:
* Replaced the unused `JAR_JAR_EMOJI_ID` constant with a new `URL_SHAME_EMOJI` constant in `nicknamer/src/nicknamer/config.rs`.