### PR TITLE
feat(logging): log created messages and handle events

### DIFF
--- a/nicknamer/src/main.rs
+++ b/nicknamer/src/main.rs
@@ -6,7 +6,7 @@ use self::nicknamer::connectors::discord::serenity::{Context, SerenityDiscordCon
 use self::nicknamer::connectors::discord::server_member::ServerMember;
 use crate::nicknamer::commands::nick::{NickService, NickServiceImpl};
 use crate::nicknamer::commands::reveal::{Revealer, RevealerImpl};
-use log::{LevelFilter, info};
+use log::{LevelFilter, debug, info};
 use log4rs::Config;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Logger, Root};
@@ -115,7 +115,7 @@ async fn main() {
                         FullEvent::Message { new_message } => {
                             on_message_create(ctx, &new_message).await;
                         }
-                        _ => {}
+                        _ => debug!("Unhandled event: {:?}", event),
                     }
                     Ok(())
                 })


### PR DESCRIPTION
This pull request introduces a new feature to log message contents when a message is created in a Discord server. It also includes updates to the event handling and gateway intents to support this functionality.

### Feature Addition: Message Logging
* Added a new function `on_message_create` to log the content of messages when they are created. (`nicknamer/src/main.rs`, [nicknamer/src/main.rsR85-R89](diffhunk://#diff-6810ec788f9819cb9595e7694605d57126d1d04599e9bc7ea38c974b1f287cb9R85-R89))
* Updated the framework's `event_handler` to call `on_message_create` when a `FullEvent::Message` is triggered. (`nicknamer/src/main.rs`, [nicknamer/src/main.rsR112-R122](diffhunk://#diff-6810ec788f9819cb9595e7694605d57126d1d04599e9bc7ea38c974b1f287cb9R112-R122))

### Gateway Intents Update
* Added the `GUILD_MESSAGES` intent to enable receiving message-related events. (`nicknamer/src/main.rs`, [nicknamer/src/main.rsR102](diffhunk://#diff-6810ec788f9819cb9595e7694605d57126d1d04599e9bc7ea38c974b1f287cb9R102))

### Code Import Update
* Updated the `use` statement to include `FullEvent` from `poise::serenity_prelude` for handling message events. (`nicknamer/src/main.rs`, [nicknamer/src/main.rsL14-R14](diffhunk://#diff-6810ec788f9819cb9595e7694605d57126d1d04599e9bc7ea38c974b1f287cb9L14-R14))