### PR TITLE
refactor(user): remove unused conversion implementation

### DIFF
--- a/nicknamer/src/nicknamer/user.rs
+++ b/nicknamer/src/nicknamer/user.rs
@@ -10,16 +10,6 @@ pub struct User {
     pub nick_name: Option<String>,
     pub real_name: Option<String>,
 }
-impl From<server_member::ServerMember> for User {
-    fn from(discord_member: server_member::ServerMember) -> Self {
-        Self {
-            id: discord_member.id,
-            user_name: discord_member.user_name.clone(),
-            nick_name: discord_member.nick_name.clone(),
-            real_name: None,
-        }
-    }
-}
 
 impl From<&server_member::ServerMember> for User {
     fn from(discord_member: &server_member::ServerMember) -> Self {


### PR DESCRIPTION
This pull request simplifies the `User` struct implementation in the `nicknamer` module by removing an unused conversion method.

Code cleanup:

* [`nicknamer/src/nicknamer/user.rs`](diffhunk://#diff-8eaa93ac0469369c22a080d43707b87679bff189e2dcb4d0997a8b4c898a76efL13-L22): Removed the `impl From<server_member::ServerMember> for User` implementation, which was redundant or unused, to streamline the codebase.