### PR TITLE
fix: skip params in on_message_create

### DIFF
--- a/nicknamer/src/main.rs
+++ b/nicknamer/src/main.rs
@@ -196,7 +196,7 @@ async fn configure_discord_bot() -> anyhow::Result<serenity::Client> {
 }
 
 /// Logs message contents when a message is created
-#[tracing::instrument(skip(_ctx))]
+#[tracing::instrument(skip_all)]
 async fn on_message_create(_ctx: &serenity::Context, new_message: &Message) {
     info!("Message created: {}", new_message.content);
 }

--- a/nicknamer/src/main.rs
+++ b/nicknamer/src/main.rs
@@ -196,7 +196,7 @@ async fn configure_discord_bot() -> anyhow::Result<serenity::Client> {
 }
 
 /// Logs message contents when a message is created
-#[tracing::instrument]
+#[tracing::instrument(skip(_ctx))]
 async fn on_message_create(_ctx: &serenity::Context, new_message: &Message) {
     info!("Message created: {}", new_message.content);
 }


### PR DESCRIPTION
This pull request includes a minor change to the `on_message_create` function in `nicknamer/src/main.rs`. The `#[tracing::instrument]` attribute was updated to include the `skip_all` parameter to prevent logging of all arguments, likely for performance or privacy reasons.This pull request makes a minor adjustment to the `on_message_create` function in `nicknamer/src/main.rs`. The change updates the `#[tracing::instrument]` attribute to skip the `_ctx` parameter during tracing.

* [`nicknamer/src/main.rs`](diffhunk://#diff-6810ec788f9819cb9595e7694605d57126d1d04599e9bc7ea38c974b1f287cb9L199-R199): Modified the `#[tracing::instrument]` attribute in the `on_message_create` function to skip the `_ctx` parameter, preventing it from being included in tracing logs.