### PR TITLE
feat: don't reveal kermit

### DIFF
--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -6,18 +6,15 @@ applyTo: "**/*.rs"
 
 Before returning any code, ensure all the following guidelines are strictly followed. If any guideline is not met, do not return the code and instead provide an error message indicating the issue.
 
-## Build check
-Run `cargo check --all-targets --all-features`.
-*   If it fails, fix the code until the command succeeds.
+## Commmands
 
-## Lint
-Run `cargo clippy --all-targets --all-features -- -D warnings`.
-*   Resolve every warning; treat warnings as errors.
-*   Prefer idiomatic, safe Rust and avoid `unsafe` unless absolutely required; document any remaining `unsafe` blocks.
-
-## Test
-Run `cargo test --all-features --all-targets`.
-*   All unit, integration, and doc tests must pass.
+Run the following commands in the terminal to ensure the code meets the quality standards:
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo check --all-targets --all-features
+cargo test --all-features --all-targets
+```
 
 ## Error Handling
 *   Avoid logging. Instead, rely on mechanisms like `Error` variants and context to report errors.

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -4,7 +4,7 @@ applyTo: "**/*.rs"
 ---
 # Rust Quality Gatekeeper – Copilot Instructions
 
-Before returning any code:
+Before returning any code, ensure all the following guidelines are strictly followed. If any guideline is not met, do not return the code and instead provide an error message indicating the issue.
 
 ## Build check
 Run `cargo check --all-targets --all-features`.

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -6,7 +6,7 @@ applyTo: "**/*.rs"
 
 Before returning any code, ensure all the following guidelines are strictly followed. If any guideline is not met, do not return the code and instead provide an error message indicating the issue.
 
-## Commmands
+## Commands
 
 Run the following commands in the terminal to ensure the code meets the quality standards:
 ```bash

--- a/nicknamer/config/config.toml
+++ b/nicknamer/config/config.toml
@@ -1,3 +1,4 @@
 [nicknamer.reveal]
 insult = "ya dingus"
 role_to_mention = "Code Monkeys"
+he_who_shall_not_be_named = 899501665365929985

--- a/nicknamer/src/nicknamer/config.rs
+++ b/nicknamer/src/nicknamer/config.rs
@@ -17,6 +17,8 @@ pub struct RevealConfig {
     pub insult: String,
     /// The role to mention when revealing a nickname.
     pub role_to_mention: String,
+    // Field to store the ID of the user who should not be named.
+    pub he_who_shall_not_be_named: u64,
 }
 
 /// Configuration for the nicknamer application.
@@ -60,6 +62,7 @@ mod tests {
                 [nicknamer.reveal]
                 insult = "test insult"
                 role_to_mention = "test role"
+                he_who_shall_not_be_named = 1
             "#;
 
             // Act
@@ -68,6 +71,7 @@ mod tests {
             // Assert
             assert_eq!(config.nicknamer.reveal.insult, "test insult");
             assert_eq!(config.nicknamer.reveal.role_to_mention, "test role");
+            assert_eq!(config.nicknamer.reveal.he_who_shall_not_be_named, 1);
         }
 
         #[test]
@@ -78,6 +82,7 @@ mod tests {
                 [nicknamer.reveal]
                 insult = ""
                 role_to_mention = ""
+                he_who_shall_not_be_named = 0
             "#;
 
             // Act
@@ -86,6 +91,7 @@ mod tests {
             // Assert
             assert_eq!(config.nicknamer.reveal.insult, "");
             assert_eq!(config.nicknamer.reveal.role_to_mention, "");
+            assert_eq!(config.nicknamer.reveal.he_who_shall_not_be_named, 0);
         }
 
         #[test]
@@ -96,6 +102,7 @@ mod tests {
                 [nicknamer.reveal]
                 insult = "Special chars: !@#$%^&*()"
                 role_to_mention = "More special: 😊🚀👍"
+                he_who_shall_not_be_named = 2
             "#;
 
             // Act
@@ -107,6 +114,7 @@ mod tests {
                 config.nicknamer.reveal.role_to_mention,
                 "More special: 😊🚀👍"
             );
+            assert_eq!(config.nicknamer.reveal.he_who_shall_not_be_named, 2);
         }
     }
 
@@ -118,6 +126,7 @@ mod tests {
                 reveal: RevealConfig {
                     insult: "test insult".to_string(),
                     role_to_mention: "test role".to_string(),
+                    he_who_shall_not_be_named: 123456789,
                 },
             },
         };
@@ -128,6 +137,7 @@ mod tests {
         // Assert
         assert!(toml_str.contains("insult = \"test insult\""));
         assert!(toml_str.contains("role_to_mention = \"test role\""));
+        assert!(toml_str.contains("he_who_shall_not_be_named = 123456789"));
     }
 
     #[test]
@@ -138,6 +148,7 @@ mod tests {
                 reveal: RevealConfig {
                     insult: "roundtrip insult".to_string(),
                     role_to_mention: "roundtrip role".to_string(),
+                    he_who_shall_not_be_named: 987654321,
                 },
             },
         };
@@ -156,6 +167,13 @@ mod tests {
         assert_eq!(
             deserialized_config.nicknamer.reveal.role_to_mention,
             "roundtrip role"
+        );
+        assert_eq!(
+            deserialized_config
+                .nicknamer
+                .reveal
+                .he_who_shall_not_be_named,
+            987654321
         );
     }
 }

--- a/nicknamer/src/nicknamer/config.rs
+++ b/nicknamer/src/nicknamer/config.rs
@@ -17,7 +17,7 @@ pub struct RevealConfig {
     pub insult: String,
     /// The role to mention when revealing a nickname.
     pub role_to_mention: String,
-    // Field to store the ID of the user who should not be named.
+    /// The ID of the user who should not be revealed in `reveal_all` commands.
     pub he_who_shall_not_be_named: u64,
 }
 

--- a/nicknamer/src/nicknamer/mod.rs
+++ b/nicknamer/src/nicknamer/mod.rs
@@ -137,7 +137,7 @@ impl<REPO: NamesRepository + Send + Sync, DISCORD: DiscordConnector + Send + Syn
                 !member.is_bot && member.id != self.config.reveal.he_who_shall_not_be_named
             })
             .collect();
-        
+
         let real_names = self.names_repository.load_real_names().await?;
 
         // Reveal users with real names
@@ -284,7 +284,7 @@ mod nicknamer_impl_tests {
     use crate::nicknamer::connectors::discord::MockDiscordConnector;
     use crate::nicknamer::names::MockNamesRepository;
 
-    static HE_WHO_SHALL_NOT_BE_NAMED : u64 = 899501665365929985; // Example ID for tests
+    static HE_WHO_SHALL_NOT_BE_NAMED: u64 = 899501665365929985; // Example ID for tests
 
     // Helper function to create a test NicknamerConfig for tests
     fn create_test_config() -> config::NicknamerConfig {


### PR DESCRIPTION
This pull request introduces several updates to the `nicknamer` project and Rust quality guidelines. The most significant changes include adding a new configuration field to exclude a specific user from nickname reveals, enhancing functionality in the `reveal_all` method, and improving test coverage. Additionally, the Rust quality guidelines have been restructured for clarity.

### Updates to `nicknamer` functionality:

* **New configuration field for exclusions:**
  - Added `he_who_shall_not_be_named` to the `RevealConfig` struct and configuration file (`nicknamer/config/config.toml`, `nicknamer/src/nicknamer/config.rs`). This field stores the ID of a user to exclude from `reveal_all` commands. [[1]](diffhunk://#diff-fccd0105e0baf35e392147e28f3ec519dd71793336c3b9dec1a526564ac68914R4) [[2]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR20-R21)

* **Filtering logic in `reveal_all`:**
  - Updated the `reveal_all` method to filter out bots and the user specified by `he_who_shall_not_be_named`.

* **Enhanced tracing:**
  - Added `#[tracing::instrument]` to key methods (`reveal_all`, `reveal`, and `change_nickname`) for better observability. [[1]](diffhunk://#diff-07a0fe09624b230bb5684351f3393a49ece5143b9158ca709a4f44c287da5733R125-R140) [[2]](diffhunk://#diff-07a0fe09624b230bb5684351f3393a49ece5143b9158ca709a4f44c287da5733R221) [[3]](diffhunk://#diff-07a0fe09624b230bb5684351f3393a49ece5143b9158ca709a4f44c287da5733R245)

### Test coverage improvements:

* **Unit tests for new functionality:**
  - Added tests to verify that `reveal_all` correctly excludes the user defined in `he_who_shall_not_be_named`.
  - Updated existing tests to include assertions for the new configuration field. [[1]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR65) [[2]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR74) [[3]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR85) [[4]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR94) [[5]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR105) [[6]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR117) [[7]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR129) [[8]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR140) [[9]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR151) [[10]](diffhunk://#diff-4f58686613f241475e2e83e2c96c6b29b89e85060995a9e24274e9dcfa622d0dR171-R177)

### Updates to Rust quality guidelines:

* **Reorganized quality checks:**
  - Consolidated build, lint, and test commands into a single list for improved clarity.