### PR TITLE
chore: update quality check commands in Rust instructions

### DIFF
--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -10,10 +10,8 @@ Before returning any code, ensure all the following guidelines are strictly foll
 
 Run the following commands in the terminal to ensure the code meets the quality standards:
 ```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo check --all-targets --all-features
-cargo test --all-features --all-targets
+cargo make clippy
+cargo make dev-test-flow
 ```
 
 ## Error Handling


### PR DESCRIPTION
This pull request updates the Rust project instructions to streamline the development workflow by replacing individual commands with a unified task runner.

### Workflow simplification:
* [`.github/instructions/rust.instructions.md`](diffhunk://#diff-66925704832d33c44a0776bad863e48d07dd2f35fd157065efa14e78023c4f02L13-R14): Replaced separate `cargo` commands (`cargo fmt`, `cargo clippy`, `cargo check`, and `cargo test`) with `cargo make` commands (`cargo make clippy` and `cargo make dev-test-flow`) to simplify and standardize the code quality and testing process.