### PR TITLE
fix: simplify config loading

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9
       - uses: davidB/rust-cargo-make@4be7185ac95f20945b64d772e7f6f09e1bd753b6
       - name: Run CI
-        run: cargo make workspace-ci-flow
+        run: cargo make --profile ci workspace-ci-flow
       - uses: taiki-e/install-action@92f69c195229fe62d58b4d697ab4bc75def98e76
         with:
           tool: cargo-llvm-cov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,6 @@ dependencies = [
  "anyhow",
  "askama",
  "axum",
- "dotenvy",
  "envy",
  "migration",
  "mockall",

--- a/nicknamer/server/Cargo.toml
+++ b/nicknamer/server/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 anyhow = "1.0.98"
 askama = "0.14.0"
 axum = "0.8.4"
-dotenvy = "0.15.7"
 envy = "0.4.2"
 migration = { version = "0.1.0", path = "./migration" }
 mockall = "0.13.1"

--- a/nicknamer/server/Makefile.toml
+++ b/nicknamer/server/Makefile.toml
@@ -1,2 +1,14 @@
+env_files = [
+   { path = "./.env", profile = "development"},
+]
+
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.run]
+command = "cargo"
+args = [
+    "run",
+    "--bin",
+    "nicknamer_server",
+]

--- a/nicknamer/server/src/lib.rs
+++ b/nicknamer/server/src/lib.rs
@@ -135,7 +135,9 @@ pub async fn start_web_server(config: config::Config) -> anyhow::Result<()> {
     use axum::Router;
 
     let app = Router::new().route("/health", axum::routing::get(health_check));
-    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", config.port)).await?;
+    let server_address = format!("0.0.0.0:{}", config.port);
+    let listener = tokio::net::TcpListener::bind(&server_address).await?;
+    tracing::info!("Web server running on http://{}", server_address);
 
     let db = Database::connect(&config.db_url).await?;
     migration::Migrator::up(&db, None).await?;

--- a/nicknamer/server/src/lib.rs
+++ b/nicknamer/server/src/lib.rs
@@ -1,6 +1,5 @@
 use migration::MigratorTrait;
 use sea_orm::Database;
-use tracing::info;
 
 pub mod config {
     use serde::Deserialize;

--- a/nicknamer/server/src/lib.rs
+++ b/nicknamer/server/src/lib.rs
@@ -4,23 +4,25 @@ use tracing::info;
 
 pub mod config {
     use serde::Deserialize;
-    use tracing::info;
-
     #[derive(Deserialize, Debug)]
     pub struct Config {
+        #[serde(default = "default_db_url")]
         pub db_url: String,
+        #[serde(default = "default_port")]
         pub port: u16,
     }
 
     impl Config {
         pub fn from_env() -> Self {
-            match dotenvy::dotenv() {
-                Ok(_) => info!("Loaded environment variables from .env file"),
-                Err(e) => info!("Failed to load .env file: {}", e),
-            };
-
             envy::from_env().expect("Failed to load configuration from environment variables")
         }
+    }
+
+    fn default_db_url() -> String {
+        "postgres://user:password@localhost/nicknamer".to_string()
+    }
+    fn default_port() -> u16 {
+        8080
     }
 }
 pub mod entities;
@@ -129,6 +131,7 @@ pub mod user {
     }
 }
 
+#[tracing::instrument]
 pub async fn start_web_server(config: config::Config) -> anyhow::Result<()> {
     use axum::Router;
 

--- a/nicknamer/server/src/lib.rs
+++ b/nicknamer/server/src/lib.rs
@@ -5,7 +5,6 @@ pub mod config {
     use serde::Deserialize;
     #[derive(Deserialize, Debug)]
     pub struct Config {
-        #[serde(default = "default_db_url")]
         pub db_url: String,
         #[serde(default = "default_port")]
         pub port: u16,
@@ -15,10 +14,6 @@ pub mod config {
         pub fn from_env() -> Self {
             envy::from_env().expect("Failed to load configuration from environment variables")
         }
-    }
-
-    fn default_db_url() -> String {
-        "postgres://user:password@localhost/nicknamer".to_string()
     }
     fn default_port() -> u16 {
         8080

--- a/nicknamer/server/src/lib.rs
+++ b/nicknamer/server/src/lib.rs
@@ -140,7 +140,7 @@ pub async fn start_web_server(config: config::Config) -> anyhow::Result<()> {
 
     let db = Database::connect(&config.db_url).await?;
     migration::Migrator::up(&db, None).await?;
-    axum::serve(listener, app.into_make_service()).await?;
+    axum::serve(listener, app).await?;
     Ok(())
 }
 

--- a/nicknamer/server/src/main.rs
+++ b/nicknamer/server/src/main.rs
@@ -2,5 +2,5 @@
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt().init();
     let config = nicknamer_server::config::Config::from_env();
-    nicknamer_server::start_web_server(config).await
+    nicknamer_server::web::start_web_server(config).await
 }

--- a/nicknamer/server/src/main.rs
+++ b/nicknamer/server/src/main.rs
@@ -1,6 +1,6 @@
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt().init();
     let config = nicknamer_server::config::Config::from_env();
     nicknamer_server::start_web_server(config).await
 }


### PR DESCRIPTION
This pull request introduces several updates to improve the configuration, logging, and functionality of the `nicknamer/server` project, as well as minor workflow adjustments. Key changes include enhancements to the web server setup, the addition of a health check endpoint, and improvements to environment configuration handling.

### Web Server Enhancements:
* Added a `/health` endpoint to the web server for basic health checks and replaced the use of `axum::Router::new()` with a router that includes the new endpoint.
* Updated the server to log its address using `tracing::info` and refactored the server address to use a formatted string.

### Environment Configuration Improvements:
* Replaced `dotenvy` with `envy` for environment variable management, removing the explicit `.env` loading logic.
* Added a default port value (`8080`) to the `Config` struct using `#[serde(default)]`.
* Introduced `env_files` configuration in `Makefile.toml` to support environment file profiles.

### Logging and Observability:
* Replaced `tracing_subscriber::fmt::init()` with `tracing_subscriber::fmt().init()` for improved logging initialization.
* Added `#[tracing::instrument]` annotations to the `start_web_server` and `health_check` functions for better observability.

### Workflow Adjustments:
* Updated the GitHub Actions workflow to use the `--profile ci` flag with `cargo make` for more efficient CI runs.

### Dependency Updates:
* Removed the `dotenvy` dependency from `Cargo.toml` as it is no longer used.