### PR TITLE
fix: reorder steps in CI workflow for clarity

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,12 +19,11 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48
-      - uses: davidB/rust-cargo-make@4be7185ac95f20945b64d772e7f6f09e1bd753b6
-      - name: Run CI
-        run: cargo make --profile ci workspace-ci-flow
       - uses: taiki-e/install-action@7b20dfd705618832f20d29066e34aa2f2f6194c2
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-make,cargo-llvm-cov
+      - name: Run CI
+        run: cargo make --profile ci workspace-ci-flow
       - run: cargo llvm-cov --all-features --workspace --lcov --output-path codecov.json
       - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
         with:


### PR DESCRIPTION
This pull request updates the CI workflow configuration in `.github/workflows/run-tests.yml` to streamline the tool setup process and improve compatibility. The most important change is the consolidation of tool installation steps and reordering the CI commands for better clarity.

### CI Workflow Updates:

* Consolidated the installation of `cargo-make` and `cargo-llvm-cov` into a single step using `taiki-e/install-action` for improved efficiency.
* Reordered the `Run CI` command to follow the tool installation step, ensuring proper execution order.