### PR TITLE
fix: update rustsec/audit-check action to a specific commit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2.0.0
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the dependency version for the `rustsec/audit-check` action in the `.github/workflows/audit.yml` file. The change ensures the workflow uses a specific commit hash instead of a version tag for better stability and reproducibility.

* [`.github/workflows/audit.yml`](diffhunk://#diff-93a89f16f6717d1e4e4e27ec20ef916e3355c7aa890ca74cd9b12db30d8a899fL16-R16): Updated `rustsec/audit-check` action from version `v2.0.0` to commit hash `69366f33c96575abad1ee0dba8212993eecbe998` to ensure reproducibility in the audit workflow