### PR TITLE
refactor: switch to config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +668,25 @@ dependencies = [
 
 [[package]]
 name = "config"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini 0.20.0",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust2 0.8.1",
+]
+
+[[package]]
+name = "config"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
@@ -665,12 +696,12 @@ dependencies = [
  "json5",
  "pathdiff",
  "ron",
- "rust-ini",
+ "rust-ini 0.21.1",
  "serde",
  "serde_json",
  "toml",
  "winnow",
- "yaml-rust2",
+ "yaml-rust2 0.10.2",
 ]
 
 [[package]]
@@ -996,15 +1027,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "envy"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1360,7 +1382,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1368,6 +1390,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1378,6 +1404,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2053,6 +2088,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,7 +2146,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "config",
+ "config 0.15.11",
  "include_dir",
  "mockall",
  "poise",
@@ -2126,7 +2167,7 @@ dependencies = [
  "anyhow",
  "askama",
  "axum",
- "envy",
+ "config 0.14.1",
  "migration",
  "mockall",
  "sea-orm",
@@ -2140,6 +2181,16 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2880,6 +2931,16 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-ini"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
@@ -3602,7 +3663,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.2",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.9.0",
  "log",
  "memchr",
@@ -4993,13 +5054,24 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.8.4",
+]
+
+[[package]]
+name = "yaml-rust2"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18b783b2c2789414f8bb84ca3318fc9c2d7e7be1c22907d37839a58dedb369d3"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.10.0",
 ]
 
 [[package]]

--- a/nicknamer/server/Cargo.toml
+++ b/nicknamer/server/Cargo.toml
@@ -11,7 +11,7 @@ testcontainers-modules = { version = "0.12.1", features = ["postgres"] }
 anyhow = "1.0.98"
 askama = "0.14.0"
 axum = "0.8.4"
-envy = "0.4.2"
+config = "0.14.1"
 migration = { version = "0.1.0", path = "./migration" }
 sea-orm = { version = "1.1.12", features = [
     "sqlx-postgres",

--- a/nicknamer/server/src/lib.rs
+++ b/nicknamer/server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config {
     use serde::Deserialize;
+
     #[derive(Deserialize, Debug)]
     pub struct Config {
         pub db_url: String,
@@ -10,10 +11,17 @@ pub mod config {
     }
 
     impl Config {
-        pub fn from_env() -> Self {
-            envy::from_env().expect("Failed to load configuration from environment variables")
+        /// Loads configuration from environment variables.
+        pub fn from_env() -> anyhow::Result<Self> {
+            let settings = config::Config::builder()
+                .add_source(config::Environment::default())
+                .build()?;
+
+            let config: Config = settings.try_deserialize()?;
+            Ok(config)
         }
     }
+
     fn default_port() -> u16 {
         8080
     }

--- a/nicknamer/server/src/main.rs
+++ b/nicknamer/server/src/main.rs
@@ -1,6 +1,6 @@
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt().init();
-    let config = nicknamer_server::config::Config::from_env();
+    let config = nicknamer_server::config::Config::from_env()?;
     nicknamer_server::web::start_web_server(config).await
 }


### PR DESCRIPTION
This pull request introduces changes to improve configuration handling in the `nicknamer/server` module by replacing the `envy` crate with the `config` crate and updating related code accordingly. The changes enhance error handling and provide more flexibility for configuration management.

### Dependency Updates:
* Replaced the `envy` crate with the `config` crate in `Cargo.toml`. (`[nicknamer/server/Cargo.tomlL14-R14](diffhunk://#diff-213e1c552518c208ade98261a016f8371e45fe72dd0c43b68b15e1687a892659L14-R14)`)

### Code Updates:
* Updated the `Config` struct in `nicknamer/server/src/lib.rs` to use the `config` crate for loading environment variables, replacing the `envy` crate. This includes adding a builder pattern for configuration sources and improving error handling with `anyhow::Result`. (`[nicknamer/server/src/lib.rsL13-R24](diffhunk://#diff-887c014e0a555201cd4c85ec3a9813fb60b05f5ded07956c4cd10e1336a30ef8L13-R24)`)
* Modified the `main` function in `nicknamer/server/src/main.rs` to handle errors using the `?` operator when loading configuration with the updated `Config::from_env` method. (`[nicknamer/server/src/main.rsL4-R4](diffhunk://#diff-04f435579adefc333b58b8dbb2c575cde0a469c5bf4ffc1826d069a44a80cd9eL4-R4)`)