### PR TITLE
fix: Rename add endpoint

### DIFF
--- a/nicknamer/server/src/name.rs
+++ b/nicknamer/server/src/name.rs
@@ -227,7 +227,7 @@ async fn render_names_table<F>(
     sort_fn: F,
 ) -> Result<String, NameError>
 where
-    F: FnMut(&mut Vec<Name>),
+    F: FnOnce(&mut Vec<Name>),
 {
     let mut names = name_service.get_all_names().await?;
     sort_fn(&mut names);

--- a/nicknamer/server/src/name.rs
+++ b/nicknamer/server/src/name.rs
@@ -468,7 +468,7 @@ async fn get_name_row_handler(
 pub fn create_name_router(state: NameState) -> Router {
     Router::new()
         .route("/names", get(names_handler).post(create_name_handler))
-        .route("/names/form", get(add_name_form_handler))
+        .route("/names/add", get(add_name_form_handler))
         .route(
             "/names/{id}",
             get(get_name_row_handler)

--- a/nicknamer/server/src/name.rs
+++ b/nicknamer/server/src/name.rs
@@ -227,7 +227,7 @@ async fn render_names_table<F>(
     sort_fn: F,
 ) -> Result<String, NameError>
 where
-    F: FnOnce(&mut Vec<Name>),
+    F: FnMut(&mut Vec<Name>),
 {
     let mut names = name_service.get_all_names().await?;
     sort_fn(&mut names);

--- a/nicknamer/server/templates/names/names.html
+++ b/nicknamer/server/templates/names/names.html
@@ -24,7 +24,7 @@
             <h2 class="card-title text-2xl">Stored Names</h2>
             <button
               class="btn btn-primary"
-              hx-get="/names/form"
+              hx-get="/names/add"
               hx-target="#add-name-form"
               hx-swap="innerHTML"
             >

--- a/nicknamer/server/tests/names_endpoints_tests.rs
+++ b/nicknamer/server/tests/names_endpoints_tests.rs
@@ -335,7 +335,7 @@ async fn can_serve_add_name_form() {
     let app = create_name_router(name_state);
 
     let request = Request::builder()
-        .uri("/names/form")
+        .uri("/names/add")
         .body(Body::empty())
         .unwrap();
 

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_empty_names_table_when_no_names_exist.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_empty_names_table_when_no_names_exist.snap
@@ -5,7 +5,7 @@ expression: snapshot_data
 test_context: empty_names_table
 status: 200
 headers:
-  content-length: "3090"
+  content-length: "3089"
   content-type: text/html; charset=utf-8
 html_body:
   - "<!DOCTYPE html>"
@@ -49,7 +49,7 @@ html_body:
   - "            <h2 class=\"card-title text-2xl\">Stored Names</h2>"
   - "            <button"
   - "              class=\"btn btn-primary\""
-  - "              hx-get=\"/names/form\""
+  - "              hx-get=\"/names/add\""
   - "              hx-target=\"#add-name-form\""
   - "              hx-swap=\"innerHTML\""
   - "            >"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_names_table_when_names_exist.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_names_table_when_names_exist.snap
@@ -5,7 +5,7 @@ expression: snapshot_data
 test_context: names_table_with_existing_names
 status: 200
 headers:
-  content-length: "5649"
+  content-length: "5648"
   content-type: text/html; charset=utf-8
 html_body:
   - "<!DOCTYPE html>"
@@ -49,7 +49,7 @@ html_body:
   - "            <h2 class=\"card-title text-2xl\">Stored Names</h2>"
   - "            <button"
   - "              class=\"btn btn-primary\""
-  - "              hx-get=\"/names/form\""
+  - "              hx-get=\"/names/add\""
   - "              hx-target=\"#add-name-form\""
   - "              hx-swap=\"innerHTML\""
   - "            >"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__names_endpoint_returns_correct_content_type.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__names_endpoint_returns_correct_content_type.snap
@@ -5,7 +5,7 @@ expression: snapshot_data
 test_context: names_endpoint_content_type_check
 status: 200
 headers:
-  content-length: "3090"
+  content-length: "3089"
   content-type: text/html; charset=utf-8
 html_body:
   - "<!DOCTYPE html>"
@@ -49,7 +49,7 @@ html_body:
   - "            <h2 class=\"card-title text-2xl\">Stored Names</h2>"
   - "            <button"
   - "              class=\"btn btn-primary\""
-  - "              hx-get=\"/names/form\""
+  - "              hx-get=\"/names/add\""
   - "              hx-target=\"#add-name-form\""
   - "              hx-swap=\"innerHTML\""
   - "            >"


### PR DESCRIPTION
This pull request refactors the `nicknamer/server/src/name.rs` file to reduce code duplication and improve maintainability. It introduces a helper function for rendering sorted names tables, updates several handlers to use this new function, and modifies routes and tests to reflect a change in the endpoint for adding names. 

### Code Refactoring and Reusability Improvements:
* Added `render_names_table` helper function to centralize logic for fetching, sorting, and rendering names tables, minimizing code duplication across handlers. (`nicknamer/server/src/name.rs`, [nicknamer/server/src/name.rsR222-R237](diffhunk://#diff-e5ae5478e1c569b28d41f131b339a2991cd19bd8ce91a22847dc5e0ad5bfbc44R222-R237))
* Updated `create_name_handler` and `delete_name_handler` to use the new `render_names_table` function for rendering sorted names tables. (`nicknamer/server/src/name.rs`, [[1]](diffhunk://#diff-e5ae5478e1c569b28d41f131b339a2991cd19bd8ce91a22847dc5e0ad5bfbc44L352-R373) [[2]](diffhunk://#diff-e5ae5478e1c569b28d41f131b339a2991cd19bd8ce91a22847dc5e0ad5bfbc44L383-R402)

### Endpoint and Route Updates:
* Changed the route for the "add name" form from `/names/form` to `/names/add` for consistency and clarity. (`nicknamer/server/src/name.rs`, [nicknamer/server/src/name.rsL458-R471](diffhunk://#diff-e5ae5478e1c569b28d41f131b339a2991cd19bd8ce91a22847dc5e0ad5bfbc44L458-R471))
* Updated corresponding templates and tests to reflect the new `/names/add` endpoint. (`nicknamer/server/templates/names/names.html`, [[1]](diffhunk://#diff-03b613581f765bc2ebad18012283b712474e8088ecad2ef3cc5355b4f8cd7555L27-R27); `nicknamer/server/tests/names_endpoints_tests.rs`, [[2]](diffhunk://#diff-22469e347ed6a799e06e798332ab0c6a5cf3c400f04751fd9f9206c6fde08829L338-R338)

### Snapshot Updates:
* Adjusted snapshots to account for the updated endpoint and minor changes in content length due to the route modification. (`nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_empty_names_table_when_no_names_exist.snap`, [[1]](diffhunk://#diff-d55eae210535d7dd1ddbcf18471f4a26f58ece150f06e28f0f0412cd26a8eb18L8-R8) [[2]](diffhunk://#diff-d55eae210535d7dd1ddbcf18471f4a26f58ece150f06e28f0f0412cd26a8eb18L52-R52); `nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_names_table_when_names_exist.snap`, [[3]](diffhunk://#diff-e81598f034940b3298d990101d634d3ad9279c24a135de5ae6f39ffcc79635b0L8-R8) [[4]](diffhunk://#diff-e81598f034940b3298d990101d634d3ad9279c24a135de5ae6f39ffcc79635b0L52-R52); `nicknamer/server/tests/snapshots/names_endpoints_tests__names_endpoint_returns_correct_content_type.snap`, [[5]](diffhunk://#diff-95fac24f28f580b2bc8ae2b9b424b5f9321f5813208657e0126d6349ec2e5d58L8-R8) [[6]](diffhunk://#diff-95fac24f28f580b2bc8ae2b9b424b5f9321f5813208657e0126d6349ec2e5d58L52-R52)