### PR TITLE
refactor: Update header filtering logic and remove content-length

### DIFF
--- a/nicknamer/server/tests/names_endpoints_tests.rs
+++ b/nicknamer/server/tests/names_endpoints_tests.rs
@@ -32,7 +32,7 @@ impl HttpResponseSnapshot {
         Self {
             test_context: test_context.to_string(),
             status: status.as_u16(),
-            headers: filter_non_time_sensitive_headers(headers),
+            headers: filter_variable_headers(headers),
             html_body: normalize_html_for_snapshot(body_text),
         }
     }
@@ -45,9 +45,9 @@ fn normalize_html_for_snapshot(html: &str) -> Vec<String> {
     html.lines().map(|line| line.to_string()).collect()
 }
 
-/// Filter out time-sensitive headers from response headers for snapshot testing.
-fn filter_non_time_sensitive_headers(headers: &axum::http::HeaderMap) -> BTreeMap<String, String> {
-    let time_sensitive_headers = [
+/// Filter out variable headers from response headers for snapshot testing.
+fn filter_variable_headers(headers: &axum::http::HeaderMap) -> BTreeMap<String, String> {
+    let variable_headers = [
         "date",
         "expires",
         "last-modified",
@@ -56,13 +56,14 @@ fn filter_non_time_sensitive_headers(headers: &axum::http::HeaderMap) -> BTreeMa
         "x-request-id",
         "x-trace-id",
         "set-cookie",
+        "content-length",
     ];
 
     headers
         .iter()
         .filter_map(|(name, value)| {
             let name_str = name.as_str().to_lowercase();
-            if time_sensitive_headers.contains(&name_str.as_str()) {
+            if variable_headers.contains(&name_str.as_str()) {
                 None
             } else {
                 value.to_str().ok().map(|v| (name_str, v.to_string()))

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_create_multiple_names_and_update_count.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_create_multiple_names_and_update_count.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: create_multiple_names_update_count
 status: 200
 headers:
-  content-length: "4550"
   content-type: text/html; charset=utf-8
 html_body:
   - ""

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_create_name_successfully.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_create_name_successfully.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: create_name_successfully
 status: 200
 headers:
-  content-length: "1860"
   content-type: text/html; charset=utf-8
 html_body:
   - ""

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_delete_name_and_update_table_count.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_delete_name_and_update_table_count.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: delete_name_and_update_table_count
 status: 200
 headers:
-  content-length: "3204"
   content-type: text/html; charset=utf-8
 html_body:
   - ""

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_delete_name_successfully.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_delete_name_successfully.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: delete_name_successfully
 status: 200
 headers:
-  content-length: "645"
   content-type: text/html; charset=utf-8
 html_body:
   - ""

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_empty_names_table_when_no_names_exist.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_empty_names_table_when_no_names_exist.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: empty_names_table
 status: 200
 headers:
-  content-length: "3089"
   content-type: text/html; charset=utf-8
 html_body:
   - "<!DOCTYPE html>"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_names_table_when_names_exist.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_display_names_table_when_names_exist.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: names_table_with_existing_names
 status: 200
 headers:
-  content-length: "5648"
   content-type: text/html; charset=utf-8
 html_body:
   - "<!DOCTYPE html>"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_handle_delete_request_for_nonexistent_name.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_handle_delete_request_for_nonexistent_name.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: delete_nonexistent_name_error
 status: 500
 headers:
-  content-length: "458"
   content-type: text/html; charset=utf-8
   hx-reswap: innerHTML
 html_body:

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_handle_edit_form_request_for_nonexistent_name.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_handle_edit_form_request_for_nonexistent_name.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: edit_form_nonexistent_name_error
 status: 500
 headers:
-  content-length: "458"
   content-type: text/html; charset=utf-8
   hx-reswap: innerHTML
 html_body:

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_handle_form_with_special_characters_in_name.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_handle_form_with_special_characters_in_name.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: form_with_special_characters
 status: 200
 headers:
-  content-length: "1866"
   content-type: text/html; charset=utf-8
 html_body:
   - ""

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_handle_update_request_for_nonexistent_name.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_handle_update_request_for_nonexistent_name.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: update_nonexistent_name_error
 status: 500
 headers:
-  content-length: "458"
   content-type: text/html; charset=utf-8
   hx-reswap: innerHTML
 html_body:

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_serve_add_name_form.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_serve_add_name_form.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: add_name_form
 status: 200
 headers:
-  content-length: "1640"
   content-type: text/html; charset=utf-8
 html_body:
   - "<div class=\"bg-base-200 p-4 rounded-lg\">"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_serve_edit_name_form.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_serve_edit_name_form.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: edit_name_form
 status: 200
 headers:
-  content-length: "1052"
   content-type: text/html; charset=utf-8
 html_body:
   - "<tr id=\"name-row-1\">"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_update_name_successfully.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_update_name_successfully.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: update_name_successfully
 status: 200
 headers:
-  content-length: "1350"
   content-type: text/html; charset=utf-8
 html_body:
   - "<tr id=\"name-row-1\">"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_update_name_with_empty_string.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_update_name_with_empty_string.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: update_name_with_empty_string
 status: 200
 headers:
-  content-length: "1335"
   content-type: text/html; charset=utf-8
 html_body:
   - "<tr id=\"name-row-1\">"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_update_name_with_special_characters.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_update_name_with_special_characters.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: update_name_with_special_characters
 status: 200
 headers:
-  content-length: "1362"
   content-type: text/html; charset=utf-8
 html_body:
   - "<tr id=\"name-row-1\">"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__can_update_name_with_very_long_string.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__can_update_name_with_very_long_string.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: update_name_with_very_long_string
 status: 200
 headers:
-  content-length: "1435"
   content-type: text/html; charset=utf-8
 html_body:
   - "<tr id=\"name-row-1\">"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__cannot_create_name_with_duplicate_discord_id.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__cannot_create_name_with_duplicate_discord_id.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: duplicate_discord_id_error
 status: 422
 headers:
-  content-length: "458"
   content-type: text/html; charset=utf-8
   hx-reswap: innerHTML
 html_body:

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__delete_endpoint_returns_correct_content_type.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__delete_endpoint_returns_correct_content_type.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: delete_endpoint_content_type_check
 status: 200
 headers:
-  content-length: "645"
   content-type: text/html; charset=utf-8
 html_body:
   - ""

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__delete_endpoint_returns_table_fragment_not_full_page.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__delete_endpoint_returns_table_fragment_not_full_page.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: delete_returns_table_fragment
 status: 200
 headers:
-  content-length: "645"
   content-type: text/html; charset=utf-8
 html_body:
   - ""

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__edit_form_endpoint_returns_correct_content_type.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__edit_form_endpoint_returns_correct_content_type.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: edit_form_endpoint_content_type_check
 status: 200
 headers:
-  content-length: "1052"
   content-type: text/html; charset=utf-8
 html_body:
   - "<tr id=\"name-row-1\">"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__names_endpoint_returns_correct_content_type.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__names_endpoint_returns_correct_content_type.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: names_endpoint_content_type_check
 status: 200
 headers:
-  content-length: "3089"
   content-type: text/html; charset=utf-8
 html_body:
   - "<!DOCTYPE html>"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__post_endpoint_returns_table_fragment_not_full_page.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__post_endpoint_returns_table_fragment_not_full_page.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: table_fragment_not_full_page
 status: 200
 headers:
-  content-length: "1865"
   content-type: text/html; charset=utf-8
 html_body:
   - ""

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__update_endpoint_returns_correct_content_type.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__update_endpoint_returns_correct_content_type.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: update_endpoint_content_type_check
 status: 200
 headers:
-  content-length: "1354"
   content-type: text/html; charset=utf-8
 html_body:
   - "<tr id=\"name-row-1\">"

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__update_endpoint_returns_name_row_fragment_not_full_page.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__update_endpoint_returns_name_row_fragment_not_full_page.snap
@@ -5,7 +5,6 @@ expression: snapshot_data
 test_context: update_returns_name_row_fragment
 status: 200
 headers:
-  content-length: "1351"
   content-type: text/html; charset=utf-8
 html_body:
   - "<tr id=\"name-row-1\">"


### PR DESCRIPTION
This pull request refactors the snapshot testing logic for the `nicknamer/server/tests/names_endpoints_tests.rs` file by replacing the filtering of "time-sensitive headers" with "variable headers" and updating corresponding snapshot files to reflect this change. The key updates include modifying the header filtering function, adjusting snapshot tests, and ensuring consistency across snapshot data.

### Refactoring header filtering logic:

* [`nicknamer/server/tests/names_endpoints_tests.rs`](diffhunk://#diff-22469e347ed6a799e06e798332ab0c6a5cf3c400f04751fd9f9206c6fde08829L35-R35): Renamed the function `filter_non_time_sensitive_headers` to `filter_variable_headers` and updated its logic to include the `content-length` header in the list of filtered headers. This ensures that variable headers like `content-length` are excluded from snapshot testing for better test reliability. [[1]](diffhunk://#diff-22469e347ed6a799e06e798332ab0c6a5cf3c400f04751fd9f9206c6fde08829L35-R35) [[2]](diffhunk://#diff-22469e347ed6a799e06e798332ab0c6a5cf3c400f04751fd9f9206c6fde08829L48-R50) [[3]](diffhunk://#diff-22469e347ed6a799e06e798332ab0c6a5cf3c400f04751fd9f9206c6fde08829R59-R66)

### Updates to snapshot files:

* Multiple snapshot files under `nicknamer/server/tests/snapshots/` were updated to remove the `content-length` header from the snapshot data. This aligns with the new filtering logic and ensures consistent snapshot comparisons. Examples include `names_endpoints_tests__can_create_multiple_names_and_update_count.snap` [[1]](diffhunk://#diff-25db49b82a34c1702447628f69e74942ffc1658065b8e743bf01d1b7869e761fL8) `names_endpoints_tests__can_create_name_successfully.snap` [[2]](diffhunk://#diff-c363263c19413fa15546e57f7180f9e95767d67763a9a87e583e59fdc6c8138dL8) and others.