### PR TITLE
perf: Index on discord id

### DIFF
--- a/nicknamer/server/migration/src/lib.rs
+++ b/nicknamer/server/migration/src/lib.rs
@@ -2,6 +2,7 @@ pub use sea_orm_migration::prelude::*;
 
 mod m20220101_000001_create_user_table;
 mod m20250618_072946_rename_table_name;
+mod m20250622_231317_add_index;
 
 pub struct Migrator;
 
@@ -11,6 +12,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20220101_000001_create_user_table::Migration),
             Box::new(m20250618_072946_rename_table_name::Migration),
+            Box::new(m20250622_231317_add_index::Migration),
         ]
     }
 }

--- a/nicknamer/server/migration/src/m20250622_231317_add_index.rs
+++ b/nicknamer/server/migration/src/m20250622_231317_add_index.rs
@@ -1,0 +1,36 @@
+use sea_orm_migration::{prelude::*, schema::*};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_discord_id")
+                    .table(Name::Table)
+                    .col(Name::DiscordId)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_discord_id")
+                    .table(Name::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum Name {
+    Table,
+    DiscordId,
+}

--- a/nicknamer/server/migration/src/m20250622_231317_add_index.rs
+++ b/nicknamer/server/migration/src/m20250622_231317_add_index.rs
@@ -1,4 +1,4 @@
-use sea_orm_migration::{prelude::*, schema::*};
+use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -29,7 +29,7 @@ impl MigrationTrait for Migration {
     }
 }
 
-#[derive(Iden)]
+#[derive(DeriveIden)]
 enum Name {
     Table,
     DiscordId,


### PR DESCRIPTION
This pull request introduces a new database migration to add an index to the `DiscordId` column in the `Table` table. The changes include defining the migration, registering it in the migrator, and implementing the logic for creating and dropping the index.

### Migration-related changes:

* **Added new migration module:** Introduced `m20250622_231317_add_index.rs` to define the migration for adding and removing an index on the `DiscordId` column in the `Table` table. The `up` method creates the index, while the `down` method drops it. (`nicknamer/server/migration/src/m20250622_231317_add_index.rs`)
* **Registered the new migration:** Updated the `Migrator` implementation to include the new migration in the list of migrations. (`nicknamer/server/migration/src/lib.rs`)

### Module organization:

* **Added module reference:** Included `mod m20250622_231317_add_index;` in the migration module declarations to ensure the new migration is recognized. (`nicknamer/server/migration/src/lib.rs`)