### PR TITLE
chore: remove Makefile.toml files from various directories

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,6 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/run-tests.yml` file. The `timeout-minutes` configuration for the `ci` job has been removed, allowing the job to run without a predefined timeout.