### PR TITLE
feat: add API for auth

### DIFF
--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -32,4 +32,4 @@ If the tests pass, then go to the root of the repository and run `mise test`.
 
 - Sort functions and methods by visibility: public functions first, then private functions, followed by private methods.
 - Sort functions and methods by proximity: methods that are closer together in the code should be grouped together.
-- Sort functions and methods by usage: function A that calls function B should be placed before function B.
+- Functions and methods should read top down. The function that is called first should be at the top, followed by the function that is called next, and so on.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,7 @@ dependencies = [
  "regex",
  "sea-orm",
  "serde",
+ "serde_json",
  "testcontainers-modules",
  "thiserror 2.0.12",
  "time",

--- a/nicknamer/server/Cargo.toml
+++ b/nicknamer/server/Cargo.toml
@@ -24,6 +24,7 @@ sea-orm = { version = "1.1.12", features = [
     "macros",
 ] }
 serde = "1.0.219"
+serde_json = "1.0"
 thiserror = "2.0.12"
 time = "0.3.36"
 tokio = "1.45.1"

--- a/nicknamer/server/src/auth.rs
+++ b/nicknamer/server/src/auth.rs
@@ -375,7 +375,7 @@ pub mod api {
 
         /// API authentication middleware that extracts the current user from Authorization Bearer header.
         /// Sets the CurrentUser extension if a valid JWT token is found in the Authorization header.
-        pub async fn api_auth_middleware(
+        pub async fn auth_user_middleware(
             State(state): State<Arc<AuthState>>,
             headers: HeaderMap,
             mut request: Request,

--- a/nicknamer/server/src/auth.rs
+++ b/nicknamer/server/src/auth.rs
@@ -332,80 +332,9 @@ mod tests {
             .unwrap();
         assert_eq!(body, "Protected content");
     }
-
-    #[tokio::test]
-    async fn json_api_login_works_correctly() {
-        use axum::body::Body;
-        use axum::http::{Request, StatusCode};
-        use tower::ServiceExt;
-
-        let config = Config {
-            db_url: "".to_string(),
-            port: 8080,
-            admin_username: "admin".to_string(),
-            admin_password: "password".to_string(),
-            jwt_secret: "test_secret".to_string(),
-        };
-
-        let auth_state = Arc::new(AuthState::from_config(&config));
-        let app = api::v1::create_api_router(auth_state);
-
-        // Test 1: Valid credentials should return JWT token
-        let login_payload = r#"{"username": "admin", "password": "password"}"#;
-
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/api/v1/login")
-                    .header("content-type", "application/json")
-                    .body(Body::from(login_payload))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let body_str = std::str::from_utf8(&body).unwrap();
-
-        // Basic assertions - should contain expected fields
-        assert!(body_str.contains("\"token\""));
-        assert!(body_str.contains("\"username\":\"admin\""));
-        assert!(body_str.contains("\"expires_at\""));
-
-        // Test 2: Invalid credentials should return error
-        let invalid_payload = r#"{"username": "admin", "password": "wrong_password"}"#;
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/api/v1/login")
-                    .header("content-type", "application/json")
-                    .body(Body::from(invalid_payload))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let body_str = std::str::from_utf8(&body).unwrap();
-
-        assert!(body_str.contains("\"error\":\"INVALID_CREDENTIALS\""));
-        assert!(body_str.contains("\"message\":\"Invalid username or password\""));
-    }
 }
 
-mod api {
+pub mod api {
     pub mod v1 {
 
         /// JSON request payload for API login
@@ -419,8 +348,6 @@ mod api {
         #[derive(serde::Serialize, Debug)]
         pub struct LoginResponse {
             pub token: String,
-            pub username: String,
-            pub expires_at: i64,
         }
 
         /// JSON response for API errors
@@ -462,21 +389,12 @@ mod api {
                         )
                     })?;
 
-                // Calculate expiration time
-                let now = chrono::Utc::now();
-                let expire = chrono::Duration::hours(24);
-                let expires_at = (now + expire).timestamp();
-
-                let response = LoginResponse {
-                    token: jwt_token,
-                    username: payload.username,
-                    expires_at,
-                };
+                let response = LoginResponse { token: jwt_token };
 
                 Ok(Json(response))
             } else {
                 Err((
-                    StatusCode::UNAUTHORIZED,
+                    StatusCode::BAD_REQUEST,
                     Json(ErrorResponse {
                         error: "INVALID_CREDENTIALS".to_string(),
                         message: "Invalid username or password".to_string(),

--- a/nicknamer/server/src/web/mod.rs
+++ b/nicknamer/server/src/web/mod.rs
@@ -213,11 +213,18 @@ mod api {
 
     use crate::auth::{self, AuthState};
 
-    use axum::Router;
+    use axum::{Router, middleware::from_fn_with_state};
 
-    /// Creates the API rouets for JSON API endpoints.
+    use tower::ServiceBuilder;
+
+    /// Creates the API routes for JSON API endpoints.
     pub fn create_api_router(auth_state: Arc<AuthState>) -> axum::Router {
         let login_router = auth::api::v1::create_api_router(auth_state.clone());
-        Router::new().nest("/api/v1", login_router)
+        Router::new()
+            .nest("/api/v1", login_router)
+            .layer(ServiceBuilder::new().layer(from_fn_with_state(
+                auth_state,
+                auth::api::v1::auth_user_middleware,
+            )))
     }
 }

--- a/nicknamer/server/src/web/mod.rs
+++ b/nicknamer/server/src/web/mod.rs
@@ -215,6 +215,7 @@ mod api {
 
     use axum::Router;
 
+    /// Creates the API rouets for JSON API endpoints.
     pub fn create_api_router(auth_state: Arc<AuthState>) -> axum::Router {
         let login_router = auth::api::v1::create_api_router(auth_state.clone());
         Router::new().nest("/api/v1", login_router)

--- a/nicknamer/server/tests/auth_endpoints_tests.rs
+++ b/nicknamer/server/tests/auth_endpoints_tests.rs
@@ -243,3 +243,83 @@ async fn can_render_login_page_with_homepage_button_when_user_logged_in() {
 
     assert_yaml_snapshot!(snapshot_data);
 }
+
+mod json_api_tests {
+    use crate::common::JsonApiResponseSnapshot;
+
+    use super::*;
+    use nicknamer_server::auth::api::v1::create_api_router;
+
+    /// Test helper to create JSON API test app.
+    async fn create_json_api_test_app() -> (axum::Router, Arc<AuthState>) {
+        let auth_state = setup_auth_state().await;
+        let app = create_api_router(auth_state.clone());
+        (app, auth_state)
+    }
+
+    #[tokio::test]
+    async fn can_login_with_valid_credentials_via_json_api() {
+        let (app, _auth_state) = create_json_api_test_app().await;
+
+        let login_payload = r#"{"username": "admin", "password": "password"}"#;
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v1/login")
+            .header("content-type", "application/json")
+            .body(Body::from(login_payload))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        assert!(
+            status.is_success(),
+            "Expected success status, got: {}",
+            status
+        );
+        // Empty body because we print the token in the body, and the token contains a expiration time
+        // which is dynamic and not suitable for snapshot testing.
+        let body_text = "";
+        let snapshot_data = JsonApiResponseSnapshot::new(
+            body_text,
+            status,
+            &headers,
+            "json_api_login_with_valid_credentials",
+        );
+        assert_yaml_snapshot!(snapshot_data);
+    }
+
+    #[tokio::test]
+    async fn can_reject_invalid_credentials_via_json_api() {
+        let (app, _auth_state) = create_json_api_test_app().await;
+
+        let invalid_payload = r#"{"username": "admin", "password": "wrong_password"}"#;
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v1/login")
+            .header("content-type", "application/json")
+            .body(Body::from(invalid_payload))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_text = std::str::from_utf8(&body).unwrap();
+
+        let snapshot_data = JsonApiResponseSnapshot::new(
+            body_text,
+            status,
+            &headers,
+            "json_api_reject_invalid_credentials",
+        );
+
+        assert_yaml_snapshot!(snapshot_data);
+    }
+}

--- a/nicknamer/server/tests/common/mod.rs
+++ b/nicknamer/server/tests/common/mod.rs
@@ -51,6 +51,34 @@ impl HttpResponseSnapshot {
     }
 }
 
+/// Snapshot structure for JSON API responses
+#[derive(serde::Serialize)]
+pub struct JsonApiResponseSnapshot {
+    status: u16,
+    headers: std::collections::BTreeMap<String, String>,
+    body: serde_json::Value,
+    test_name: String,
+}
+
+impl JsonApiResponseSnapshot {
+    pub fn new(
+        body_text: &str,
+        status: axum::http::StatusCode,
+        headers: &axum::http::HeaderMap,
+        test_name: &str,
+    ) -> Self {
+        let body = serde_json::from_str(body_text)
+            .unwrap_or_else(|_| serde_json::Value::String(body_text.to_string()));
+
+        Self {
+            status: status.as_u16(),
+            headers: filter_variable_headers(headers),
+            body,
+            test_name: test_name.to_string(),
+        }
+    }
+}
+
 /// Normalize HTML content for consistent snapshots by removing dynamic values.
 pub fn normalize_html_for_snapshot(html: &str) -> Vec<String> {
     // Split HTML by newlines and convert to Vec<String>

--- a/nicknamer/server/tests/snapshots/auth_endpoints_tests__api__v1__can_login_with_valid_credentials_via_json_api.snap
+++ b/nicknamer/server/tests/snapshots/auth_endpoints_tests__api__v1__can_login_with_valid_credentials_via_json_api.snap
@@ -1,0 +1,9 @@
+---
+source: nicknamer/server/tests/auth_endpoints_tests.rs
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body: Intentionally empty body for snapshot testing
+test_name: json_api_login_with_valid_credentials

--- a/nicknamer/server/tests/snapshots/auth_endpoints_tests__api__v1__can_reject_invalid_credentials_via_json_api.snap
+++ b/nicknamer/server/tests/snapshots/auth_endpoints_tests__api__v1__can_reject_invalid_credentials_via_json_api.snap
@@ -1,0 +1,11 @@
+---
+source: nicknamer/server/tests/auth_endpoints_tests.rs
+expression: snapshot_data
+---
+status: 400
+headers:
+  content-type: application/json
+body:
+  error: INVALID_CREDENTIALS
+  message: Invalid username or password
+test_name: json_api_reject_invalid_credentials

--- a/nicknamer/server/tests/snapshots/auth_endpoints_tests__json_api_tests__can_login_with_valid_credentials_via_json_api.snap
+++ b/nicknamer/server/tests/snapshots/auth_endpoints_tests__json_api_tests__can_login_with_valid_credentials_via_json_api.snap
@@ -1,0 +1,9 @@
+---
+source: nicknamer/server/tests/auth_endpoints_tests.rs
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body: ""
+test_name: json_api_login_with_valid_credentials

--- a/nicknamer/server/tests/snapshots/auth_endpoints_tests__json_api_tests__can_reject_invalid_credentials_via_json_api.snap
+++ b/nicknamer/server/tests/snapshots/auth_endpoints_tests__json_api_tests__can_reject_invalid_credentials_via_json_api.snap
@@ -1,0 +1,11 @@
+---
+source: nicknamer/server/tests/auth_endpoints_tests.rs
+expression: snapshot_data
+---
+status: 400
+headers:
+  content-type: application/json
+body:
+  error: INVALID_CREDENTIALS
+  message: Invalid username or password
+test_name: json_api_reject_invalid_credentials


### PR DESCRIPTION
This pull request introduces a JSON API for authentication in the `nicknamer/server` module, along with supporting changes to integrate the API into the web application and add tests for its functionality. Key updates include the addition of new API routes, middleware for handling authentication, and snapshot-based tests for validating the API's behavior.

### JSON API for Authentication:

* [`nicknamer/server/src/auth.rs`](diffhunk://#diff-0f9911316cfaf20adb875fc5fa7dd8405bf0312f48530201dbdbc5406226974eR336-R434): Added a new `api::v1` module containing structs for JSON request/response payloads (`JsonLoginRequest`, `LoginResponse`, `ErrorResponse`) and functions for handling login requests (`json_login_handler`) and middleware for extracting authenticated users (`auth_user_middleware`). Also introduced a router creation function (`create_api_router`) for API endpoints.

### Integration with Web Application:

* [`nicknamer/server/src/web/mod.rs`](diffhunk://#diff-daaef702460c454d9e68dffcd627e0067a81d411af229c29e8b5aa2a186dea98R21): Updated the `start_web_server` function to integrate the JSON API router into the main application. Added a new `create_web_handler` function to configure routes and middleware for the web application. Introduced a nested API router under `/api/v1` using the `create_api_router` function. [[1]](diffhunk://#diff-daaef702460c454d9e68dffcd627e0067a81d411af229c29e8b5aa2a186dea98R21) [[2]](diffhunk://#diff-daaef702460c454d9e68dffcd627e0067a81d411af229c29e8b5aa2a186dea98R65-L71) [[3]](diffhunk://#diff-daaef702460c454d9e68dffcd627e0067a81d411af229c29e8b5aa2a186dea98L93-R136) [[4]](diffhunk://#diff-daaef702460c454d9e68dffcd627e0067a81d411af229c29e8b5aa2a186dea98R210-R230)

### Dependency Updates:

* [`nicknamer/server/Cargo.toml`](diffhunk://#diff-213e1c552518c208ade98261a016f8371e45fe72dd0c43b68b15e1687a892659R27): Added the `serde_json` crate to support JSON serialization and deserialization in the API.

### Snapshot-Based Testing:

* [`nicknamer/server/tests/auth_endpoints_tests.rs`](diffhunk://#diff-a49cc29dbe29a511726524db2cb8927c9f98fd7dfe380cae8d7880ff3139d58eR246-R332): Added tests for the JSON API login functionality, including cases for valid and invalid credentials. Tests use snapshot assertions to validate API responses.
* [`nicknamer/server/tests/common/mod.rs`](diffhunk://#diff-606bcffb6f57b8ef2ab49604c9b7f06190b6d70e81c43174d1d840783e0b977bR54-R81): Added a new `JsonApiResponseSnapshot` struct for normalizing JSON API responses in snapshots.
* Snapshot files (`nicknamer/server/tests/snapshots/*.snap`): Added snapshots for JSON API responses, ensuring consistent testing of API behavior. [[1]](diffhunk://#diff-9b63df88492aec0e25b811cc90afaa9d0435a0a296dbe89ebe7ccf2cd819ff54R1-R9) [[2]](diffhunk://#diff-6da5ba1f1e8017a5927f196d6eb0a94469e981be211ddc010d62aaa923f6ca8aR1-R11) [[3]](diffhunk://#diff-044550407bcc169f7666a3a799193431611b813821f033a5f9cc66db29ec5437R1-R9)

### Code Style Update:

* [`.github/instructions/rust.instructions.md`](diffhunk://#diff-66925704832d33c44a0776bad863e48d07dd2f35fd157065efa14e78023c4f02L35-R35): Updated guidelines for sorting functions and methods to emphasize a top-down reading order based on call hierarchy.