### PR TITLE
feat: add openAPI spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +969,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -2027,6 +2048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,6 +2248,8 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -2968,6 +3000,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.100",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3590,6 +3656,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
@@ -4648,6 +4720,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.9.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5206,4 +5320,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.9.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/nicknamer/server/Cargo.toml
+++ b/nicknamer/server/Cargo.toml
@@ -37,4 +37,6 @@ tower-http = { version = "0.6.6", features = [
 tracing = "0.1.41"
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.19"
+utoipa = { version = "5.4.0", features = ["axum_extras"] }
+utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/nicknamer/server/src/name/api/v1.rs
+++ b/nicknamer/server/src/name/api/v1.rs
@@ -2,12 +2,16 @@ use crate::name::{Name, NameService, NameState};
 use axum::{Router, extract::State, http::StatusCode, response::Json, routing::get};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 /// JSON representation of a Name for API responses.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct NameJson {
+    /// Unique identifier for the name
     id: u32,
+    /// Discord user ID associated with the name
     discord_id: u64,
+    /// The actual name/nickname
     name: String,
 }
 
@@ -22,20 +26,32 @@ impl From<Name> for NameJson {
 }
 
 /// API response for listing all names.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct NamesResponse {
+    /// List of names
     names: Vec<NameJson>,
+    /// Total number of names
     count: usize,
 }
 
 /// Error response for API errors.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ErrorResponse {
+    /// Error message
     error: String,
 }
 
 /// Handler for GET /api/v1/names - Returns all names in JSON format.
 #[tracing::instrument(skip(state))]
+#[utoipa::path(
+    get,
+    path = "/api/v1/names",
+    responses(
+        (status = 200, description = "Successfully retrieved all names", body = NamesResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "Names"
+)]
 pub async fn get_names_handler(
     State(state): State<Arc<NameState>>,
 ) -> Result<Json<NamesResponse>, (StatusCode, Json<ErrorResponse>)> {

--- a/nicknamer/server/src/web/api.rs
+++ b/nicknamer/server/src/web/api.rs
@@ -78,7 +78,7 @@ pub(crate) mod v1 {
         let api_routes = public_routes.merge(protected_routes);
 
         Router::new()
-            .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+            .merge(SwaggerUi::new(SWAGGER_UI_PATH).url(API_DOCS_PATH, ApiDoc::openapi()))
             .nest("/api/v1", api_routes)
             .layer(ServiceBuilder::new().layer(from_fn_with_state(
                 auth_state,

--- a/nicknamer/server/src/web/api.rs
+++ b/nicknamer/server/src/web/api.rs
@@ -65,6 +65,9 @@ pub(crate) mod v1 {
     )]
     pub struct ApiDoc;
 
+    const API_DOCS_PATH: &str = "/api-docs/openapi.json";
+    const SWAGGER_UI_PATH: &str = "/swagger-ui";
+
     /// Creates the API routes for JSON API endpoints.
     pub fn create_api_router(
         auth_state: Arc<AuthState>,

--- a/nicknamer/server/src/web/api.rs
+++ b/nicknamer/server/src/web/api.rs
@@ -12,6 +12,38 @@ pub(crate) mod v1 {
     };
 
     use tower::ServiceBuilder;
+    use utoipa::OpenApi;
+    use utoipa_swagger_ui::SwaggerUi;
+
+    /// OpenAPI documentation for the v1 API
+    #[derive(OpenApi)]
+    #[openapi(
+        paths(
+            crate::auth::api::v1::json_login_handler,
+            crate::name::api::v1::get_names_handler,
+        ),
+        components(
+            schemas(
+                crate::auth::api::v1::JsonLoginRequest,
+                crate::auth::api::v1::LoginResponse,
+                crate::auth::api::v1::ErrorResponse,
+                crate::name::api::v1::NameJson,
+                crate::name::api::v1::NamesResponse,
+                crate::name::api::v1::ErrorResponse,
+            )
+        ),
+        tags(
+            (name = "Authentication", description = "Authentication endpoints"),
+            (name = "Names", description = "Name management endpoints")
+        ),
+        info(
+            title = "Nicknamer API",
+            version = "1.0.0",
+            description = "API for managing Discord nicknames and authentication"
+        )
+    )]
+    pub struct ApiDoc;
+
     /// Creates the API routes for JSON API endpoints.
     pub fn create_api_router(
         auth_state: Arc<AuthState>,
@@ -23,7 +55,9 @@ pub(crate) mod v1 {
             .layer(ServiceBuilder::new().layer(from_fn(auth::api::v1::require_auth_middleware)));
         let public_routes = login_router;
         let api_routes = public_routes.merge(protected_routes);
+
         Router::new()
+            .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
             .nest("/api/v1", api_routes)
             .layer(ServiceBuilder::new().layer(from_fn_with_state(
                 auth_state,

--- a/nicknamer/server/src/web/api.rs
+++ b/nicknamer/server/src/web/api.rs
@@ -12,8 +12,30 @@ pub(crate) mod v1 {
     };
 
     use tower::ServiceBuilder;
-    use utoipa::OpenApi;
+    use utoipa::{OpenApi, ToSchema};
     use utoipa_swagger_ui::SwaggerUi;
+
+    /// Unified error response for all API endpoints
+    #[derive(serde::Serialize, Debug, ToSchema)]
+    pub struct ServerErrorResponse {
+        pub error: String,
+        pub message: String,
+    }
+
+    impl ServerErrorResponse {
+        /// Create a new error response with just an error code and default message
+        pub fn new(error: String) -> Self {
+            Self {
+                error: error.clone(),
+                message: format!("An error occurred: {}", error),
+            }
+        }
+
+        /// Create a new error response with both error code and custom message
+        pub fn new_with_message(error: String, message: String) -> Self {
+            Self { error, message }
+        }
+    }
 
     /// OpenAPI documentation for the v1 API
     #[derive(OpenApi)]
@@ -26,10 +48,9 @@ pub(crate) mod v1 {
             schemas(
                 crate::auth::api::v1::JsonLoginRequest,
                 crate::auth::api::v1::LoginResponse,
-                crate::auth::api::v1::ErrorResponse,
+                ServerErrorResponse,
                 crate::name::api::v1::NameJson,
                 crate::name::api::v1::NamesResponse,
-                crate::name::api::v1::ErrorResponse,
             )
         ),
         tags(

--- a/nicknamer/server/src/web/mod.rs
+++ b/nicknamer/server/src/web/mod.rs
@@ -19,7 +19,7 @@ use crate::auth::{
 use crate::config::{self, Config};
 use crate::name::{NameState, create_name_router};
 use crate::web::api::v1::create_api_router;
-mod api;
+pub(crate) mod api;
 
 #[derive(Clone)]
 pub struct AppState {

--- a/nicknamer/server/tests/names_endpoints_tests.rs
+++ b/nicknamer/server/tests/names_endpoints_tests.rs
@@ -72,14 +72,14 @@ async fn create_editable_test_name(db: &DatabaseConnection) -> i32 {
 }
 
 /// Test helper to create a `NameState` wrapped in `Arc` for use in tests.
-/// 
+///
 /// This function is used to create a shared state (`NameState`) that can be safely
 /// accessed across multiple threads during tests. The `Arc` wrapper ensures that
 /// the state can be shared and accessed concurrently without ownership issues.
-/// 
+///
 /// # Parameters
 /// - `db`: A `DatabaseConnection` instance used to initialize the `NameState`.
-/// 
+///
 /// # Returns
 /// An `Arc<NameState>` instance that wraps the shared state.
 fn create_name_state(db: DatabaseConnection) -> Arc<NameState> {


### PR DESCRIPTION
This pull request introduces OpenAPI documentation and Swagger UI integration for the `nicknamer` server's API, enhancing its usability and maintainability. Key changes include adding OpenAPI annotations to existing API handlers and schemas, integrating Swagger UI for interactive API exploration, and updating dependencies to support these features.

### OpenAPI Documentation Enhancements:
* **Schema Annotations:** Added `ToSchema` annotations to data structures like `JsonLoginRequest`, `LoginResponse`, `ErrorResponse`, `NameJson`, and `NamesResponse` to generate OpenAPI schemas. (`[[1]](diffhunk://#diff-0b11da4b1c71745d393c5e56a72993a965d5a135ab010f3617b8042d00b0f474L2-R15)`, `[[2]](diffhunk://#diff-77da3eee01322c3f593ede684af8f35cb9bbb1433cdb82d8c5e7a22bd87b6906R5-R14)`, `[[3]](diffhunk://#diff-77da3eee01322c3f593ede684af8f35cb9bbb1433cdb82d8c5e7a22bd87b6906L25-R54)`)
* **Path Annotations:** Added `utoipa::path` annotations to API handlers (`json_login_handler` and `get_names_handler`) to define endpoint metadata, request/response schemas, and tags in OpenAPI documentation. (`[[1]](diffhunk://#diff-0b11da4b1c71745d393c5e56a72993a965d5a135ab010f3617b8042d00b0f474R82-R92)`, `[[2]](diffhunk://#diff-77da3eee01322c3f593ede684af8f35cb9bbb1433cdb82d8c5e7a22bd87b6906L25-R54)`)

### Swagger UI Integration:
* **Swagger UI Setup:** Integrated `SwaggerUi` into the API router to serve interactive documentation at `/swagger-ui`. (`[nicknamer/server/src/web/api.rsR58-R60](diffhunk://#diff-d76dc4fb4851c3c8938c8dfbbdd3bee9a27157a4cae37cd1d5a229974e40126eR58-R60)`)
* **OpenAPI Definition:** Created an `ApiDoc` struct using `utoipa::OpenApi` to consolidate endpoint paths, schemas, tags, and API metadata. (`[nicknamer/server/src/web/api.rsR15-R46](diffhunk://#diff-d76dc4fb4851c3c8938c8dfbbdd3bee9a27157a4cae37cd1d5a229974e40126eR15-R46)`)

### Dependency Updates:
* **New Dependencies:** Added `utoipa` and `utoipa-swagger-ui` to `Cargo.toml` to enable OpenAPI and Swagger UI functionality. (`[nicknamer/server/Cargo.tomlR40-R41](diffhunk://#diff-213e1c552518c208ade98261a016f8371e45fe72dd0c43b68b15e1687a892659R40-R41)`)