### PR TITLE
feat: add server ID filtering for names retrieval

### DIFF
--- a/nicknamer/server/src/name/mod.rs
+++ b/nicknamer/server/src/name/mod.rs
@@ -216,6 +216,30 @@ impl NameService<'_> {
         Ok(names)
     }
 
+    /// Retrieves name entries from the database filtered by server ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `server_id` - The server ID to filter by.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a vector of `Name` if successful, or an error otherwise.
+    #[tracing::instrument(skip(self))]
+    pub async fn get_names_by_server(
+        &self,
+        server_id: &str,
+    ) -> Result<Vec<Name>, NameServiceError> {
+        let names = name::Entity::find()
+            .filter(name::Column::ServerId.eq(server_id))
+            .all(self.db)
+            .await?
+            .into_iter()
+            .map(Name::from)
+            .collect();
+        Ok(names)
+    }
+
     /// Deletes a name entry by their ID.
     ///
     /// # Arguments

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_filter_names_by_different_server_id.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_filter_names_by_different_server_id.snap
@@ -1,0 +1,19 @@
+---
+source: nicknamer/server/tests/names_endpoints_tests.rs
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body:
+  count: 2
+  names:
+    - discord_id: 555666777
+      id: 3
+      name: Charlie
+      server_id: server2
+    - discord_id: 444333222
+      id: 4
+      name: David
+      server_id: server2
+test_name: api_v1_names_filtered_server2

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_filter_names_by_server_id.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_filter_names_by_server_id.snap
@@ -1,0 +1,19 @@
+---
+source: nicknamer/server/tests/names_endpoints_tests.rs
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body:
+  count: 2
+  names:
+    - discord_id: 123456789
+      id: 1
+      name: Alice
+      server_id: server1
+    - discord_id: 987654321
+      id: 2
+      name: Bob
+      server_id: server1
+test_name: api_v1_names_filtered_server1

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_handle_empty_server_id_parameter.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_handle_empty_server_id_parameter.snap
@@ -1,0 +1,11 @@
+---
+source: nicknamer/server/tests/names_endpoints_tests.rs
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body:
+  count: 0
+  names: []
+test_name: api_v1_names_empty_server_id

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_return_all_names_when_no_server_filter.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_return_all_names_when_no_server_filter.snap
@@ -1,0 +1,27 @@
+---
+source: nicknamer/server/tests/names_endpoints_tests.rs
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body:
+  count: 4
+  names:
+    - discord_id: 123456789
+      id: 1
+      name: Alice
+      server_id: server1
+    - discord_id: 987654321
+      id: 2
+      name: Bob
+      server_id: server1
+    - discord_id: 555666777
+      id: 3
+      name: Charlie
+      server_id: server2
+    - discord_id: 444333222
+      id: 4
+      name: David
+      server_id: server2
+test_name: api_v1_names_all_servers

--- a/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_return_empty_list_for_nonexistent_server.snap
+++ b/nicknamer/server/tests/snapshots/names_endpoints_tests__api__v1__can_return_empty_list_for_nonexistent_server.snap
@@ -1,0 +1,11 @@
+---
+source: nicknamer/server/tests/names_endpoints_tests.rs
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body:
+  count: 0
+  names: []
+test_name: api_v1_names_filtered_nonexistent


### PR DESCRIPTION
This pull request introduces support for filtering names by server ID in the `GET /api/v1/names` endpoint. It includes updates to the API, service layer, and comprehensive test coverage to ensure the new functionality works as expected.

### API Enhancements:
* Added a new query parameter `server_id` to the `GET /api/v1/names` endpoint for filtering names by server ID. Updated the handler to process this parameter and return filtered results. (`nicknamer/server/src/name/api/v1.rs`, [nicknamer/server/src/name/api/v1.rsR48-R81](diffhunk://#diff-77da3eee01322c3f593ede684af8f35cb9bbb1433cdb82d8c5e7a22bd87b6906R48-R81))
* Updated the OpenAPI documentation to reflect the new query parameter. (`nicknamer/server/src/name/api/v1.rs`, [nicknamer/server/src/name/api/v1.rsR48-R81](diffhunk://#diff-77da3eee01322c3f593ede684af8f35cb9bbb1433cdb82d8c5e7a22bd87b6906R48-R81))

### Service Layer Updates:
* Implemented the `get_names_by_server` method in the `NameService` to retrieve names filtered by server ID from the database. (`nicknamer/server/src/name/mod.rs`, [nicknamer/server/src/name/mod.rsR219-R242](diffhunk://#diff-711d9b1615f1e1ab5748fa39058a9be92a719dfc110e816bc4bce2ae009d8bfbR219-R242))

### Testing Improvements:
* Added unit tests for the `get_names_by_server` method to validate filtering logic, including edge cases like nonexistent server IDs and special characters. (`nicknamer/server/tests/name_service_tests.rs`, [nicknamer/server/tests/name_service_tests.rsR871-R966](diffhunk://#diff-db30dbdd987767bd4f92dd2cd8cbd2105963c729bd08c9d903e93aba1343672bR871-R966))
* Introduced helper functions to create test data for multiple servers. (`nicknamer/server/tests/names_endpoints_tests.rs`, [nicknamer/server/tests/names_endpoints_tests.rsR52-R89](diffhunk://#diff-22469e347ed6a799e06e798332ab0c6a5cf3c400f04751fd9f9206c6fde08829R52-R89))

### Endpoint Tests:
* Added integration tests for the `GET /api/v1/names` endpoint to verify:
  - Filtering by specific server IDs. (`nicknamer/server/tests/names_endpoints_tests.rs`, [nicknamer/server/tests/names_endpoints_tests.rsR1474-R1711](diffhunk://#diff-22469e347ed6a799e06e798332ab0c6a5cf3c400f04751fd9f9206c6fde08829R1474-R1711))
  - Handling of nonexistent server IDs, empty `server_id` parameters, and no filtering. (`nicknamer/server/tests/names_endpoints_tests.rs`, [nicknamer/server/tests/names_endpoints_tests.rsR1474-R1711](diffhunk://#diff-22469e347ed6a799e06e798332ab0c6a5cf3c400f04751fd9f9206c6fde08829R1474-R1711))

### Snapshot Updates:
* Added snapshots for the new test cases to validate API responses, including filtered results and edge cases. (`nicknamer/server/tests/snapshots/`, [[1]](diffhunk://#diff-84fdda646bb801d9355c894bf9e91c340854526d681b2829c0e2363fa43d534aR1-R19) [[2]](diffhunk://#diff-4d9a5c4aefe90a5aa271d8bb2958c9bc08a7ef68c01caa2df44cc8498c4c4de1R1-R19) [[3]](diffhunk://#diff-40e1142bb1bf66d980415cb5e5a058274ef9167e4f1e3c22f4f14e0ed437eecfR1-R11) [[4]](diffhunk://#diff-7f39b82748986c383d9d3e2e02dce7da7c7e904ea03075517be45e0d11c83935R1-R27) [[5]](diffhunk://#diff-c4017ecc60f191098b48a5d6df51b5062ea7346cb8d2440373714af37e3681cfR1-R11)