### PR TITLE
ci: add Docker Hub login step to CI workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,9 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/checkout@v4
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           username: ${{ vars.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a Docker Hub login step to the GitHub Actions workflow for running tests. This change enables the workflow to authenticate with Docker Hub, which is necessary for pulling private images or performing other Docker operations that require authentication.

Continuous integration workflow improvements:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642R20-R24): Added a step to log in to Docker Hub using the `docker/login-action@v3`, with credentials sourced from GitHub variables and secrets.